### PR TITLE
UI/UX overhaul: progress, results hero, config, brand, share & a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,38 @@
 # [DNS Bench Pro](https://dnsbenchpro.netlify.app)
 
-**[DNS Bench Pro](https://dnsbenchpro.netlify.app)** is a simple, client-side website tool designed to help you determine the closest and fastest DNS provider near your local area.
+**DNS Bench Pro** is a client-side DNS-over-HTTPS (DoH) benchmark. It helps you find the closest, fastest public resolver from your current network — privately, in the browser.
 
-## About the Name
+## Features
 
-The name "DNS Bench Pro" was chosen for its straightforwardness and simplicity. While "Pro" just popped up in my head.
+* **Client-side only** — queries run from your browser; this site does not log your IP or results.
+* **Test profiles** — Quick, Balanced, Thorough, or Comprehensive query depths with time estimates.
+* **Live progress** — warm-up vs measuring phases, determinate progress, and Stop.
+* **Configurable** — edit providers and sites, apply presets, or reset to defaults before you run.
+* **Clear results** — recommendation hero, live latency bars, cached vs uncached breakdown, sortable comparison with stable median ranks, CSV export, and share/copy summary.
 
-## Introduction
+## How to use
 
-This tool provides a straightforward way to benchmark various DNS providers from your current location. It does this by running all queries directly from your web browser, ensuring your privacy.
+1. Open [DNS Bench Pro](https://dnsbenchpro.netlify.app).
+2. Optionally click **Configure** to change providers, sites, or presets.
+3. Click **Start test** and choose a profile.
+4. Watch live results; use **Stop test** if you need to cancel.
+5. Review the recommendation, then export or share if you want.
 
-## Key Features
+## How it works
 
-*   **Client-Side Operation:** All DNS queries are initiated and processed entirely within your web browser. This means the tool relies solely on your client's capabilities.
-*   **Privacy-Focused:** Your IP address and browsing activity are never logged or stored by this tool. There is no server-side tracking whatsoever.
-*   **Local Performance Testing:** Helps you identify the DNS provider that offers the lowest latency from your specific geographical area, giving you optimal browsing speeds.
-*   **Simple & Intuitive:** Designed for ease of use, providing quick and understandable results with minimal fuss.
+The app measures DoH latency against a list of public resolvers and popular domains. A warm-up pass primes connections so cold TCP/TLS handshakes do not dominate the first timed queries. The first query per domain uses a random subdomain (uncached path); later queries measure warmer/cached responses.
 
-## How It Works
+## Local development
 
-[DNS Bench Pro](https://dnsbenchpro.netlify.app) leverages JavaScript to perform DNS lookups against a curated list of common, publicly available DNS providers. By accurately measuring the response time for each query, it helps you identify which provider offers the best performance and lowest latency relative to your current network location.
+Serve the repo root over HTTP (ES modules require a server):
 
-## Getting Started
+```bash
+npx serve .
+# or: python3 -m http.server 8080
+```
 
-Using [DNS Bench Pro](https://dnsbenchpro.netlify.app) is incredibly simple:
+Then open the printed local URL.
 
-1.  Navigate to the [DNS Bench Pro website](https://dnsbenchpro.netlify.app).
-2.  The tool will automatically begin benchmarking the listed DNS providers.
-3.  Results will be displayed directly on the page, showing the response times for each provider.
+## Inspired by
 
----
-
-## Inspired By:
-[dnsspeedtest](https://github.com/BrainicHQ/DoHSpeedTest) by **BrainicHQ**
+[DoHSpeedTest / dnsspeedtest](https://github.com/BrainicHQ/DoHSpeedTest) by **BrainicHQ**

--- a/css/style.css
+++ b/css/style.css
@@ -15,9 +15,9 @@
 	--danger: #e86a6a;
 	--radius: 8px;
 	--radius-lg: 14px;
-	--font-display: "Space Grotesk", sans-serif;
-	--font-body: "IBM Plex Sans", sans-serif;
-	--font-mono: "IBM Plex Mono", ui-monospace, monospace;
+	--font-display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+	--font-body: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+	--font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 	--shadow-soft: 0 12px 40px rgba(0, 0, 0, 0.35);
 
 	/* legacy aliases used in older markup hooks */

--- a/css/style.css
+++ b/css/style.css
@@ -1,16 +1,36 @@
-/* Prettier-formatted CSS */
 :root {
-	--background-color: #000000;
-	--card-bg: #121212;
-	--text-color: #e0e0e0;
-	--text-muted: #888;
-	--border-color: #2a2a2a;
-	--accent-color: #00aaff;
-	--danger-color: #ff5555;
-	--success-color: #55ff55;
-	--warning-color: #ffaa55;
-	--edit-color: #9d4edd;
-	--font-family: "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+	--bg-deep: #0b1016;
+	--bg-elevated: #141b24;
+	--bg-wash-a: #0f1822;
+	--bg-wash-b: #152433;
+	--bg-input: #0d141c;
+	--text: #e8eef4;
+	--text-muted: #8b9aab;
+	--line: #243041;
+	--accent: #3dd6c6;
+	--accent-dim: #2a9f94;
+	--accent-soft: rgba(61, 214, 198, 0.14);
+	--warn: #e6a756;
+	--good: #6ecf8e;
+	--danger: #e86a6a;
+	--radius: 8px;
+	--radius-lg: 14px;
+	--font-display: "Space Grotesk", sans-serif;
+	--font-body: "IBM Plex Sans", sans-serif;
+	--font-mono: "IBM Plex Mono", ui-monospace, monospace;
+	--shadow-soft: 0 12px 40px rgba(0, 0, 0, 0.35);
+
+	/* legacy aliases used in older markup hooks */
+	--background-color: var(--bg-deep);
+	--card-bg: var(--bg-elevated);
+	--text-color: var(--text);
+	--border-color: var(--line);
+	--accent-color: var(--accent);
+	--danger-color: var(--danger);
+	--success-color: var(--good);
+	--warning-color: var(--warn);
+	--edit-color: var(--accent-dim);
+	--font-family: var(--font-body);
 }
 
 * {
@@ -21,36 +41,78 @@
 
 html,
 body {
-	height: 100%;
+	min-height: 100%;
 }
 
 body {
-	background-color: var(--background-color);
-	color: var(--text-color);
-	font-family: var(--font-family);
+	background:
+		radial-gradient(
+			1200px 600px at 80% -10%,
+			rgba(61, 214, 198, 0.08),
+			transparent 55%
+		),
+		radial-gradient(
+			900px 500px at 10% 20%,
+			rgba(90, 169, 230, 0.07),
+			transparent 50%
+		),
+		linear-gradient(165deg, var(--bg-wash-a), var(--bg-deep) 45%, var(--bg-wash-b));
+	background-attachment: fixed;
+	color: var(--text);
+	font-family: var(--font-body);
 	line-height: 1.6;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.container {
-	width: 100%;
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: 2rem;
+.skip-link {
+	position: absolute;
+	left: 1rem;
+	top: -3rem;
+	background: var(--accent);
+	color: #041014;
+	padding: 0.5rem 0.85rem;
+	border-radius: var(--radius);
+	z-index: 2000;
+	font-weight: 600;
+	text-decoration: none;
 }
 
-/* --- Start Screen --- */
+.skip-link:focus {
+	top: 1rem;
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.container {
+	width: 100%;
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 2rem 1.5rem 4rem;
+}
+
+/* --- Start screen --- */
 #start-screen {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	height: 100%;
+	min-height: calc(100vh - 4rem);
 	text-align: center;
 	transition:
-		opacity 0.5s ease,
-		visibility 0.5s ease;
+		opacity 0.45s ease,
+		visibility 0.45s ease;
 }
 
 #start-screen.hidden {
@@ -59,222 +121,451 @@ body {
 	display: none;
 }
 
-/* --- Results Screen --- */
+.atmosphere {
+	pointer-events: none;
+	position: absolute;
+	inset: 10% 5% auto;
+	height: 55%;
+	background-image:
+		linear-gradient(rgba(36, 48, 65, 0.35) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(36, 48, 65, 0.35) 1px, transparent 1px);
+	background-size: 48px 48px;
+	mask-image: radial-gradient(ellipse at center, #000 20%, transparent 75%);
+	opacity: 0.7;
+}
+
+.start-container {
+	position: relative;
+	z-index: 1;
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+.brand-mark {
+	font-family: var(--font-display);
+	font-size: clamp(2.8rem, 8vw, 4.75rem);
+	font-weight: 700;
+	letter-spacing: -0.03em;
+	line-height: 1.05;
+	color: #fff;
+	margin-bottom: 1.25rem;
+}
+
+.start-tagline {
+	font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+	color: var(--text);
+	max-width: 28rem;
+	margin: 0 auto 0.75rem;
+}
+
+.start-privacy {
+	color: var(--text-muted);
+	font-size: 0.95rem;
+	margin-bottom: 2rem;
+}
+
+.start-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	justify-content: center;
+	align-items: center;
+	margin-bottom: 1.25rem;
+}
+
+.config-summary {
+	font-family: var(--font-mono);
+	font-size: 0.85rem;
+	color: var(--text-muted);
+}
+
+/* --- Results --- */
 #results-screen {
-	display: none; /* Hidden by default */
+	display: none;
 	opacity: 0;
-	transition: opacity 0.5s ease 0.3s;
+	transition: opacity 0.45s ease 0.15s;
 }
 
 #results-screen.visible {
 	display: block;
 	opacity: 1;
+	animation: settle-in 0.5s ease both;
 }
 
-h1 {
-	font-size: 3rem;
-	font-weight: 600;
-	letter-spacing: 1px;
-	color: #fff;
+@keyframes settle-in {
+	from {
+		opacity: 0;
+		transform: translateY(10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.results-hero {
+	background: var(--bg-elevated);
+	border: 1px solid var(--line);
+	border-radius: var(--radius-lg);
+	padding: 1.5rem 1.75rem;
 	margin-bottom: 2rem;
+	box-shadow: var(--shadow-soft);
 }
 
-h2 {
-	text-align: center;
+.results-hero[data-mode="recommendation"] {
+	border-color: rgba(110, 207, 142, 0.45);
+	background:
+		linear-gradient(135deg, rgba(110, 207, 142, 0.08), transparent 55%),
+		var(--bg-elevated);
+	animation: reveal-rec 0.45s ease both;
+}
+
+@keyframes reveal-rec {
+	from {
+		opacity: 0;
+		transform: translateY(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.progress-head {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 1rem;
+	margin-bottom: 0.75rem;
+}
+
+.progress-phase {
+	font-family: var(--font-display);
+	font-size: 1.15rem;
+	font-weight: 600;
+}
+
+.progress-percent {
+	font-family: var(--font-mono);
+	color: var(--accent);
+	font-size: 0.95rem;
+}
+
+.progress-track {
+	height: 8px;
+	background: #1a2430;
+	border-radius: 999px;
+	overflow: hidden;
 	margin-bottom: 1rem;
-	font-weight: 300;
-	letter-spacing: 1px;
-	font-size: 1.8rem;
-	margin-top: 3rem;
-	border-bottom: 1px solid var(--border-color);
-	padding-bottom: 0.5rem;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 1rem;
 }
 
-h2 .icon {
-	width: 24px;
-	height: 24px;
-	opacity: 0.7;
+.progress-bar-fill {
+	height: 100%;
+	width: 0;
+	background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+	border-radius: inherit;
+	transition: width 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-/* --- Controls Area --- */
-#controls-area {
-	text-align: center;
-	margin-top: 3rem;
-	padding-bottom: 2rem;
+.status-text,
+.progress-indicator {
+	color: var(--text-muted);
+	font-size: 0.95rem;
+}
+
+.progress-indicator {
+	margin-top: 0.25rem;
+	font-family: var(--font-mono);
+	font-size: 0.82rem;
+}
+
+.hero-actions {
+	margin-top: 1rem;
+}
+
+.hero-eyebrow {
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-size: 0.75rem;
+	color: var(--good);
+	font-weight: 600;
+	margin-bottom: 0.75rem;
+}
+
+.recommendation-meta {
 	display: flex;
-	justify-content: center;
-	gap: 1rem;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 0.85rem;
+}
+
+.meta-pill {
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	padding: 0.3rem 0.65rem;
+	border-radius: var(--radius);
+	border: 1px solid var(--line);
+	background: rgba(255, 255, 255, 0.03);
+	color: var(--text);
+}
+
+.recommendation-text {
+	font-size: 1.05rem;
+	max-width: 46rem;
+}
+
+.recommendation-text strong {
+	color: var(--good);
+	font-weight: 600;
+}
+
+.section-heading {
+	text-align: left;
+	margin: 2.5rem 0 1rem;
+	border-bottom: 1px solid var(--line);
+	padding-bottom: 0.85rem;
+}
+
+.section-heading h2 {
+	font-family: var(--font-display);
+	font-size: 1.45rem;
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	margin: 0;
+	border: 0;
+	padding: 0;
+	display: block;
+	text-align: left;
+}
+
+.section-note {
+	color: var(--text-muted);
+	font-size: 0.92rem;
+	margin-top: 0.35rem;
+}
+
+.secondary-section .section-heading h2 {
+	font-size: 1.2rem;
+	color: #c5d0db;
+}
+
+.legend {
+	display: flex;
+	gap: 0.75rem;
+	margin-top: 0.65rem;
+}
+
+.legend-item {
+	font-size: 0.78rem;
+	font-family: var(--font-mono);
+	padding: 0.2rem 0.5rem;
+	border-radius: 4px;
+	border: 1px solid;
+}
+
+.legend-item.cached {
+	color: var(--good);
+	border-color: rgba(110, 207, 142, 0.4);
+	background: rgba(110, 207, 142, 0.08);
+}
+
+.legend-item.uncached {
+	color: var(--warn);
+	border-color: rgba(230, 167, 86, 0.4);
+	background: rgba(230, 167, 86, 0.08);
+}
+
+/* --- Buttons --- */
+.action-button,
+.secondary-action-button,
+.ghost-button,
+.danger-button,
+.edit-btn,
+.modal-btn,
+.add-provider-btn,
+.preset-btn,
+.duration-btn {
+	font-family: var(--font-body);
 }
 
 .action-button {
-	background: linear-gradient(45deg, var(--accent-color), #0077cc);
-	color: #fff;
+	background: var(--accent);
+	color: #041014;
 	border: none;
-	padding: 1rem 2.5rem;
-	font-size: 1.2rem;
+	padding: 0.9rem 1.6rem;
+	font-size: 1rem;
 	font-weight: 600;
-	border-radius: 50px;
+	border-radius: var(--radius);
 	cursor: pointer;
 	transition:
-		transform 0.3s ease,
-		box-shadow 0.3s ease;
-	box-shadow:
-		0 4px 15px rgba(0, 170, 255, 0.2),
-		0 0 20px rgba(0, 170, 255, 0.2);
+		background 0.2s ease,
+		transform 0.2s ease;
 }
 
-.action-button:hover {
-	transform: translateY(-3px);
-	box-shadow:
-		0 8px 25px rgba(0, 170, 255, 0.4),
-		0 0 30px rgba(0, 170, 255, 0.4);
+.action-button:hover:not(:disabled) {
+	background: #58e0d1;
+	transform: translateY(-1px);
 }
 
 .action-button:disabled {
-	opacity: 0.6;
+	opacity: 0.55;
+	cursor: not-allowed;
 	transform: none;
+}
+
+.ghost-button,
+.secondary-action-button,
+.edit-btn {
+	background: transparent;
+	color: var(--text);
+	border: 1px solid var(--line);
+	padding: 0.85rem 1.25rem;
+	font-size: 0.95rem;
+	font-weight: 500;
+	border-radius: var(--radius);
+	cursor: pointer;
+	transition:
+		border-color 0.2s ease,
+		color 0.2s ease,
+		background 0.2s ease;
+}
+
+.ghost-button:hover,
+.secondary-action-button:hover,
+.edit-btn:hover:not(:disabled) {
+	border-color: var(--accent);
+	color: var(--accent);
+	background: var(--accent-soft);
+}
+
+.edit-btn:disabled {
+	opacity: 0.5;
 	cursor: not-allowed;
 }
 
-.secondary-action-button {
-	background: var(--card-bg);
-	color: var(--text-color);
-	border: 1px solid var(--border-color);
-	padding: 1rem 2.5rem;
-	font-size: 1.2rem;
-	font-weight: 600;
-	border-radius: 50px;
-	cursor: pointer;
-	transition: all 0.3s ease;
-}
-
-.secondary-action-button:hover {
-	color: var(--accent-color);
-	border-color: var(--accent-color);
-}
-
-/* --- Edit Buttons --- */
-.edit-btn {
-	background: linear-gradient(45deg, var(--edit-color), #7b2cbf);
-	color: #fff;
+.text-button {
+	background: none;
 	border: none;
-	padding: 0.5rem 1rem;
-	font-size: 0.9rem;
-	font-weight: 500;
-	border-radius: 25px;
+	color: var(--text-muted);
+	font-size: 0.95rem;
 	cursor: pointer;
-	transition:
-		transform 0.2s ease,
-		box-shadow 0.2s ease;
-	box-shadow: 0 2px 8px rgba(157, 78, 221, 0.3);
+	text-decoration: underline;
+	text-underline-offset: 3px;
+	padding: 0.5rem;
 }
 
-.edit-btn:hover {
-	transform: translateY(-2px);
-	box-shadow: 0 4px 15px rgba(157, 78, 221, 0.5);
+.text-button:hover {
+	color: var(--accent);
 }
 
-.edit-btn.small {
-	padding: 0.3rem 0.8rem;
-	font-size: 0.8rem;
+.danger-button {
+	background: rgba(232, 106, 106, 0.12);
+	color: var(--danger);
+	border: 1px solid rgba(232, 106, 106, 0.45);
+	padding: 0.65rem 1.1rem;
+	border-radius: var(--radius);
+	font-weight: 600;
+	cursor: pointer;
 }
 
-/* --- Main Graph --- */
+.danger-button:hover:not(:disabled) {
+	background: rgba(232, 106, 106, 0.2);
+}
+
+.danger-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+/* --- Graph --- */
 #main-graph-container {
-	background-color: var(--card-bg);
-	padding: 2rem;
-	border-radius: 16px;
-	border: 1px solid var(--border-color);
+	background: var(--bg-elevated);
+	padding: 1.5rem;
+	border-radius: var(--radius-lg);
+	border: 1px solid var(--line);
 }
 
 .graph-bar-wrapper {
 	display: flex;
 	align-items: center;
-	margin-bottom: 1rem;
-	font-size: 1rem;
+	margin-bottom: 0.85rem;
+	font-size: 0.95rem;
+	gap: 0.75rem;
 }
 
 .dns-name {
-	width: 140px;
+	width: 130px;
 	text-align: right;
-	margin-right: 15px;
 	white-space: nowrap;
-	color: var(--text-color);
+	overflow: hidden;
+	text-overflow: ellipsis;
 	font-weight: 500;
+	flex-shrink: 0;
 }
 
 .bar-container {
 	flex-grow: 1;
-	background-color: #222;
-	border-radius: 5px;
+	background: #1a2430;
+	border-radius: 4px;
 	overflow: hidden;
+	min-width: 0;
 }
 
 .bar {
-	height: 28px;
+	height: 22px;
 	width: 0;
-	border-radius: 5px;
+	border-radius: 4px;
 	transition: width 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 .latency-value {
-	margin-left: 15px;
-	font-weight: 700;
-	color: #fff;
-	width: 80px;
-	text-align: left;
+	width: 72px;
+	font-family: var(--font-mono);
+	font-weight: 500;
+	font-size: 0.9rem;
+	flex-shrink: 0;
 }
 
-/* FIX: Updated styles for the graph footer layout */
 .graph-footer {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-top: 1.5rem;
-	padding-top: 1.5rem;
-	border-top: 1px solid var(--border-color);
+	gap: 1rem;
+	flex-wrap: wrap;
+	margin-top: 1.25rem;
+	padding-top: 1.25rem;
+	border-top: 1px solid var(--line);
 }
 
 .graph-footer-actions {
 	display: flex;
-	gap: 0.75rem;
+	gap: 0.6rem;
+	flex-wrap: wrap;
 }
 
+.graph-footer .action-button,
 .graph-footer .edit-btn {
-	padding: 0.6rem 1.5rem;
-	font-size: 0.9rem;
-	border-radius: 8px;
+	padding: 0.55rem 1rem;
+	font-size: 0.88rem;
 }
 
-.graph-footer .action-button {
-	padding: 0.6rem 1.5rem;
-	font-size: 0.9rem;
-	border-radius: 8px;
-}
-
-/* --- Detailed Graphs --- */
+/* --- Detailed cards --- */
 #detailed-graphs-container {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-	gap: 1.5rem;
-	margin-top: 1rem;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	gap: 1rem;
 }
 
 .dns-card {
-	background-color: var(--card-bg);
-	border: 1px solid var(--border-color);
-	border-radius: 16px;
-	padding: 1.5rem;
+	background: var(--bg-elevated);
+	border: 1px solid var(--line);
+	border-radius: var(--radius-lg);
+	padding: 1.15rem;
 	opacity: 0;
-	transform: translateY(20px);
+	transform: translateY(12px);
 	transition:
-		opacity 0.5s ease,
-		transform 0.5s ease,
-		display 0s ease 0.5s;
+		opacity 0.45s ease,
+		transform 0.45s ease;
 }
 
 .dns-card.visible {
@@ -285,49 +576,48 @@ h2 .icon {
 .card-header {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
-	margin-bottom: 1rem;
-	padding-bottom: 1rem;
-	border-bottom: 1px solid var(--border-color);
-	row-gap: 0.25rem;
+	gap: 0.35rem;
+	margin-bottom: 0.85rem;
+	padding-bottom: 0.85rem;
+	border-bottom: 1px solid var(--line);
 }
 
 .card-title-section {
 	display: flex;
 	align-items: center;
-	flex-grow: 1;
 	min-width: 0;
 }
 
 .card-stats {
 	margin-left: 25px;
-	font-size: 0.9rem;
+	font-size: 0.85rem;
 	color: var(--text-muted);
+	font-family: var(--font-mono);
 }
 
 .card-color-dot {
-	width: 15px;
-	height: 15px;
+	width: 12px;
+	height: 12px;
 	border-radius: 50%;
 	margin-right: 10px;
 	flex-shrink: 0;
 }
 
 .card-title {
-	font-size: 1.2rem;
+	font-size: 1.05rem;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-/* --- New Detailed Breakdown Styles --- */
 .detailed-row {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0.4rem 0;
-	border-bottom: 1px solid #1f1f1f;
+	border-bottom: 1px solid #1b2532;
+	gap: 0.5rem;
 }
 
 .detailed-row:last-of-type {
@@ -337,213 +627,197 @@ h2 .icon {
 .detailed-row.header {
 	font-weight: 600;
 	color: var(--text-muted);
-	margin-bottom: 0.5rem;
-	font-size: 0.8rem;
+	margin-bottom: 0.35rem;
+	font-size: 0.72rem;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
-	border-bottom: 1px solid var(--border-color);
-	padding-bottom: 0.5rem;
+	letter-spacing: 0.05em;
+	border-bottom: 1px solid var(--line);
+	padding-bottom: 0.45rem;
 }
 
 .detailed-row .domain-name {
-	color: var(--text-color);
 	font-weight: 600;
 	flex-grow: 1;
-}
-
-.detailed-row.header .domain-name {
-	font-weight: 600;
-	color: var(--text-muted);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .latency-pair {
 	display: flex;
-	gap: 0.5rem;
+	gap: 0.4rem;
 	justify-content: flex-end;
-	min-width: 160px;
+	min-width: 140px;
 	flex-shrink: 0;
 }
 
 .latency-pair .detailed-latency {
-	width: 70px;
+	width: 64px;
 	text-align: center;
 	font-weight: 600;
-	padding: 0.25rem 0.4rem;
-	border-radius: 5px;
+	padding: 0.2rem 0.3rem;
+	border-radius: 4px;
 	border: 1px solid;
-	font-size: 0.9rem;
+	font-size: 0.82rem;
+	font-family: var(--font-mono);
 }
 
-/* Add the 'ms' unit via pseudo-element to prevent wrapping */
 .detailed-latency:not(.na)::after {
 	content: " ms";
-	font-size: 0.8em;
+	font-size: 0.75em;
 	color: var(--text-muted);
-	margin-left: 2px;
 }
 
 .detailed-latency.cached {
-	color: var(--success-color);
-	background-color: rgba(85, 255, 85, 0.1);
-	border-color: rgba(85, 255, 85, 0.4);
+	color: var(--good);
+	background: rgba(110, 207, 142, 0.08);
+	border-color: rgba(110, 207, 142, 0.35);
 }
 
 .detailed-latency.uncached {
-	color: var(--warning-color);
-	background-color: rgba(255, 170, 85, 0.1);
-	border-color: rgba(255, 170, 85, 0.4);
+	color: var(--warn);
+	background: rgba(230, 167, 86, 0.08);
+	border-color: rgba(230, 167, 86, 0.35);
 }
 
 .detailed-latency.failed {
-	color: var(--danger-color);
-	background-color: rgba(255, 85, 85, 0.1);
-	border-color: rgba(255, 85, 85, 0.4);
+	color: var(--danger);
+	background: rgba(232, 106, 106, 0.08);
+	border-color: rgba(232, 106, 106, 0.35);
 }
 
 .detailed-latency.na {
 	color: var(--text-muted);
-	background-color: rgba(136, 136, 136, 0.1);
-	border-color: rgba(136, 136, 136, 0.3);
+	background: rgba(139, 154, 171, 0.08);
+	border-color: rgba(139, 154, 171, 0.25);
 	font-weight: 400;
 }
 
-/* Style the header labels to look like text and align correctly */
 .detailed-row.header .detailed-latency {
 	background: none;
 	border: none;
 	font-weight: 600;
-	font-size: 0.8rem;
-	padding: 0.25rem 0.4rem;
+	font-size: 0.72rem;
+	font-family: var(--font-body);
 }
 
 .detailed-row.header .detailed-latency::after {
-	content: ""; /* Remove 'ms' unit from header */
+	content: "";
 }
 
 .detailed-row.header .cached {
-	color: var(--success-color);
+	color: var(--good);
 }
 
 .detailed-row.header .uncached {
-	color: var(--warning-color);
+	color: var(--warn);
 }
 
-/* --- Spinner and Status --- */
-.mini-spinner {
-	width: 1em;
-	height: 1em;
-	border: 2px solid var(--text-muted);
-	border-top-color: var(--accent-color);
-	border-radius: 50%;
-	animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-	to {
-		transform: rotate(360deg);
-	}
-}
-
-.status-text {
-	text-align: center;
-	margin-top: 1rem;
-	color: var(--text-muted);
-	font-style: italic;
-	height: 20px;
-}
-
-/* --- Comparison Table --- */
+/* --- Comparison --- */
 .comparison-container {
-	background-color: var(--card-bg);
-	border-radius: 16px;
-	border: 1px solid var(--border-color);
-	padding: 2rem;
-	margin-top: 2rem;
+	background: var(--bg-elevated);
+	border-radius: var(--radius-lg);
+	border: 1px solid var(--line);
+	padding: 1rem;
 	overflow-x: auto;
 }
 
 .comparison-table {
 	width: 100%;
 	border-collapse: collapse;
-	margin-top: 1rem;
+	min-width: 720px;
 }
 
 .comparison-table th,
 .comparison-table td {
-	padding: 1rem;
+	padding: 0.85rem 0.75rem;
 	text-align: center;
-	border-bottom: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--line);
 }
 
 .comparison-table th {
-	background-color: #1a1a1a;
+	background: #101820;
 	font-weight: 600;
-	color: var(--accent-color);
-	position: relative;
-	transition: color 0.2s ease;
+	color: var(--accent);
+	font-size: 0.85rem;
 }
 
 .comparison-table th[data-sort-key] {
 	cursor: pointer;
 }
 
-.comparison-table th[data-sort-key]:hover {
-	color: #fff;
-}
-
+.comparison-table th[data-sort-key]:hover,
 .comparison-table th.sorted {
 	color: #fff;
 }
 
 .sort-indicator {
-	margin-left: 8px;
-	font-size: 0.8em;
+	margin-left: 6px;
+	font-size: 0.75em;
 	display: inline-block;
 	width: 1em;
-	text-align: center;
 }
 
 .comparison-table tr:hover {
-	background-color: #1a1a1a;
+	background: rgba(255, 255, 255, 0.02);
+}
+
+.provider-cell,
+.emphasis {
+	font-weight: 600;
+}
+
+.cached-cell {
+	color: var(--good);
+}
+
+.uncached-cell {
+	color: var(--warn);
 }
 
 .rank-badge {
 	display: inline-block;
-	padding: 0.2rem 0.6rem;
-	border-radius: 15px;
-	font-size: 0.8rem;
+	padding: 0.15rem 0.55rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
 	font-weight: 600;
+	font-family: var(--font-mono);
+	background: #1a2430;
 }
 
 .rank-1 {
-	background-color: var(--success-color);
-	color: #000;
+	background: var(--good);
+	color: #041014;
 }
 .rank-2 {
-	background-color: var(--warning-color);
-	color: #000;
+	background: var(--warn);
+	color: #041014;
 }
 .rank-3 {
-	background-color: #ff8c42;
-	color: #fff;
+	background: #d9894c;
+	color: #041014;
 }
 
-/* --- Modal Styles --- */
+.empty-state {
+	text-align: center;
+	color: var(--text-muted);
+	padding: 1.5rem 1rem;
+}
+
+/* --- Modals --- */
 .modal-overlay {
 	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	background: rgba(0, 0, 0, 0.7);
-	backdrop-filter: blur(5px);
+	inset: 0;
+	background: rgba(4, 8, 12, 0.72);
+	backdrop-filter: blur(6px);
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	z-index: 1000;
 	opacity: 0;
-	transition: opacity 0.3s ease;
+	transition: opacity 0.25s ease;
 	pointer-events: none;
+	padding: 1rem;
 }
 
 .modal-overlay.visible {
@@ -552,136 +826,229 @@ h2 .icon {
 }
 
 .modal-content {
-	background: var(--card-bg);
-	padding: 0;
-	border-radius: 16px;
-	border: 1px solid var(--border-color);
-	transform: scale(0.95);
-	transition: transform 0.3s ease;
-	max-width: 600px;
-	width: 90%;
-	max-height: 80vh;
+	background: var(--bg-elevated);
+	border-radius: var(--radius-lg);
+	border: 1px solid var(--line);
+	transform: scale(0.97);
+	transition: transform 0.25s ease;
+	max-width: 560px;
+	width: 100%;
+	max-height: 85vh;
 	display: flex;
 	flex-direction: column;
+	box-shadow: var(--shadow-soft);
+}
+
+.modal-content.modal-wide {
+	max-width: 640px;
 }
 
 .modal-overlay.visible .modal-content {
 	transform: scale(1);
 }
 
+.modal-header,
+.modal-body,
+.modal-footer {
+	padding: 1.25rem 1.5rem;
+}
+
 .modal-header {
-	padding: 1.5rem 2rem;
-	border-bottom: 1px solid var(--border-color);
+	border-bottom: 1px solid var(--line);
 }
 
 .modal-header h3 {
-	font-weight: 400;
-	font-size: 1.5rem;
-	text-align: center;
+	font-family: var(--font-display);
+	font-weight: 600;
+	font-size: 1.35rem;
+	letter-spacing: -0.02em;
+}
+
+.modal-subtitle {
+	color: var(--text-muted);
+	font-size: 0.9rem;
+	margin-top: 0.35rem;
 }
 
 .modal-body {
-	padding: 2rem;
 	overflow-y: auto;
 }
 
 .modal-footer {
-	padding: 1.5rem 2rem;
-	border-top: 1px solid var(--border-color);
+	border-top: 1px solid var(--line);
 	display: flex;
-	gap: 1rem;
+	gap: 0.75rem;
 	justify-content: flex-end;
+	flex-wrap: wrap;
 }
 
 .duration-options {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
-	gap: 1rem;
+	gap: 0.75rem;
 }
 
 .duration-btn {
-	background: #252525;
-	color: var(--text-color);
-	border: 1px solid var(--border-color);
+	background: #101820;
+	color: var(--text);
+	border: 1px solid var(--line);
 	padding: 1rem;
-	border-radius: 8px;
+	border-radius: var(--radius);
 	cursor: pointer;
-	transition: all 0.2s ease;
-	text-align: center;
+	transition:
+		border-color 0.2s ease,
+		background 0.2s ease;
+	text-align: left;
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
 }
 
-.duration-btn:hover {
-	background: var(--accent-color);
-	color: #fff;
-	border-color: var(--accent-color);
+.duration-btn:hover,
+.duration-btn:focus-visible {
+	border-color: var(--accent);
+	background: var(--accent-soft);
 }
 
-.duration-btn span {
-	display: block;
+.duration-label {
+	font-weight: 600;
+	font-size: 1rem;
+}
+
+.duration-meta,
+.duration-estimate,
+.duration-hint {
 	font-size: 0.8rem;
 	color: var(--text-muted);
 }
 
-.duration-btn:hover span {
-	color: #fff;
+.duration-estimate {
+	font-family: var(--font-mono);
+	color: var(--accent);
 }
 
-/* --- Edit Forms --- */
-.edit-form {
-	text-align: left;
+.config-stats {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+}
+
+.config-stat {
+	background: #101820;
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	padding: 1rem;
+	text-align: center;
+}
+
+.config-stat-value {
+	display: block;
+	font-family: var(--font-display);
+	font-size: 1.8rem;
+	font-weight: 600;
+}
+
+.config-stat-label {
+	color: var(--text-muted);
+	font-size: 0.85rem;
+}
+
+.preset-row,
+.config-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+}
+
+.preset-btn {
+	background: #101820;
+	border: 1px solid var(--line);
+	color: var(--text);
+	border-radius: var(--radius);
+	padding: 0.55rem 0.85rem;
+	cursor: pointer;
+	font-size: 0.88rem;
+}
+
+.preset-btn:hover,
+.preset-btn:focus-visible {
+	border-color: var(--accent);
+	color: var(--accent);
+}
+
+.preset-btn.ghost {
+	background: transparent;
 }
 
 .form-group {
-	margin-bottom: 1.5rem;
+	margin-bottom: 1rem;
 }
 
 .form-group label {
 	display: block;
-	margin-bottom: 0.5rem;
+	margin-bottom: 0.4rem;
 	font-weight: 500;
-	color: var(--text-color);
 }
 
 .form-group input,
 .form-group textarea {
 	width: 100%;
-	padding: 0.8rem;
-	background: #1a1a1a;
-	border: 1px solid var(--border-color);
-	border-radius: 8px;
-	color: var(--text-color);
+	padding: 0.75rem 0.85rem;
+	background: var(--bg-input);
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	color: var(--text);
 	font-family: inherit;
 }
 
 .form-group input:focus,
-.form-group textarea:focus {
+.form-group textarea:focus,
+.action-button:focus-visible,
+.ghost-button:focus-visible,
+.secondary-action-button:focus-visible,
+.edit-btn:focus-visible,
+.modal-btn:focus-visible,
+.danger-button:focus-visible,
+.preset-btn:focus-visible,
+.duration-btn:focus-visible,
+.text-button:focus-visible {
 	outline: none;
-	border-color: var(--accent-color);
-	box-shadow: 0 0 0 2px rgba(0, 170, 255, 0.2);
+	box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 4px var(--accent-dim);
+}
+
+.form-error {
+	background: rgba(232, 106, 106, 0.1);
+	border: 1px solid rgba(232, 106, 106, 0.4);
+	color: var(--danger);
+	padding: 0.65rem 0.85rem;
+	border-radius: var(--radius);
+	margin-bottom: 1rem;
+	font-size: 0.9rem;
 }
 
 #providers-list {
 	display: flex;
 	flex-direction: column;
-	gap: 1rem;
+	gap: 0.85rem;
 }
 
 .provider-item {
 	display: flex;
-	gap: 1rem;
+	gap: 0.85rem;
 	align-items: flex-start;
-	padding: 1.25rem;
-	border: 1px solid var(--border-color);
-	border-radius: 12px;
-	background-color: #1a1a1a;
-	margin-bottom: 0; /* Use gap on parent instead */
+	padding: 1rem;
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	background: #101820;
 }
 
 .provider-inputs {
 	flex-grow: 1;
 	display: flex;
 	flex-direction: column;
-	gap: 1rem;
+	gap: 0.85rem;
 }
 
 .provider-item .form-group {
@@ -690,256 +1057,214 @@ h2 .icon {
 
 .remove-provider-btn {
 	background: transparent;
-	border: 1px solid var(--border-color);
+	border: 1px solid var(--line);
 	color: var(--text-muted);
-	width: 44px;
-	height: 44px;
-	border-radius: 8px;
+	width: 42px;
+	height: 42px;
+	border-radius: var(--radius);
 	cursor: pointer;
-	transition: all 0.2s ease;
 	flex-shrink: 0;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: 0;
-	margin-top: 26px; /* Aligns button with the top input field */
+	margin-top: 1.7rem;
 }
 
 .remove-provider-btn:hover {
-	background-color: rgba(255, 85, 85, 0.1);
-	color: var(--danger-color);
-	border-color: var(--danger-color);
+	background: rgba(232, 106, 106, 0.1);
+	color: var(--danger);
+	border-color: var(--danger);
 }
 
 .remove-provider-btn svg {
-	width: 20px;
-	height: 20px;
-}
-
-.remove-btn {
-	display: none;
+	width: 18px;
+	height: 18px;
 }
 
 .add-provider-btn {
-	background: var(--success-color);
-	color: #000;
+	background: var(--good);
+	color: #041014;
 	border: none;
-	padding: 0.8rem 1.5rem;
-	border-radius: 8px;
+	padding: 0.75rem 1.1rem;
+	border-radius: var(--radius);
 	cursor: pointer;
 	font-weight: 600;
-	margin-top: 1rem;
-	display: block;
+	margin-top: 0.85rem;
 	width: 100%;
-	text-align: center;
 }
 
 .modal-btn {
-	padding: 0.8rem 2rem;
-	border-radius: 8px;
+	padding: 0.7rem 1.25rem;
+	border-radius: var(--radius);
 	border: none;
 	cursor: pointer;
 	font-weight: 600;
-	transition: all 0.2s ease;
 }
 
 .modal-btn.primary {
-	background: var(--accent-color);
-	color: #fff;
+	background: var(--accent);
+	color: #041014;
 }
+
 .modal-btn.primary:hover {
-	background: #0099e6;
+	background: #58e0d1;
 }
 
 .modal-btn.secondary {
-	background: #333;
-	color: var(--text-color);
+	background: #1a2430;
+	color: var(--text);
+	border: 1px solid var(--line);
 }
+
 .modal-btn.secondary:hover {
-	background: #444;
+	border-color: var(--accent);
 }
 
-/* --- Recommendation Card --- */
-#recommendation-card {
-	background: linear-gradient(
-		45deg,
-		rgba(85, 255, 85, 0.1),
-		rgba(0, 170, 255, 0.1)
-	);
-	border: 1px solid var(--success-color);
-	border-radius: 16px;
-	padding: 2rem;
-	margin-bottom: 2rem;
-	text-align: center;
+.help-body section + section {
+	margin-top: 1.1rem;
 }
 
-#recommendation-card h3 {
-	font-size: 1.5rem;
-	margin-bottom: 1rem;
-	color: #fff;
+.help-body h4 {
+	font-family: var(--font-display);
+	font-size: 1rem;
+	margin-bottom: 0.35rem;
 }
 
-#recommendation-text {
-	font-size: 1.1rem;
-}
-
-#recommendation-text strong {
-	color: var(--success-color);
-	font-weight: 600;
-}
-
-/* --- Tooltip --- */
-.tooltip {
-	position: absolute;
-	bottom: 100%;
-	left: 50%;
-	transform: translateX(-50%);
-	background-color: #222;
-	color: #fff;
-	padding: 0.5rem 1rem;
-	border-radius: 6px;
-	font-size: 0.85rem;
-	white-space: nowrap;
-	opacity: 0;
-	visibility: hidden;
-	transition:
-		opacity 0.2s,
-		visibility 0.2s;
-	pointer-events: none;
-	margin-bottom: 8px;
-	z-index: 10;
-}
-
-.tooltip::after {
-	content: "";
-	position: absolute;
-	top: 100%;
-	left: 50%;
-	margin-left: -5px;
-	border-width: 5px;
-	border-style: solid;
-	border-color: #222 transparent transparent transparent;
-}
-
-th:hover .tooltip {
-	opacity: 1;
-	visibility: visible;
-}
-
-/* --- Misc --- */
-.progress-indicator {
-	text-align: center;
-	margin-top: 1rem;
-	font-size: 0.9rem;
+.help-body p {
 	color: var(--text-muted);
+	font-size: 0.95rem;
+}
+
+/* --- Controls / footer / toast --- */
+#controls-area {
+	display: flex;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-top: 2.5rem;
+	padding-bottom: 1rem;
 }
 
 .error-summary {
-	background: rgba(255, 85, 85, 0.1);
-	border: 1px solid var(--danger-color);
-	border-radius: 8px;
+	background: rgba(232, 106, 106, 0.1);
+	border: 1px solid var(--danger);
+	border-radius: var(--radius);
 	padding: 1rem;
 	margin-top: 1rem;
 	font-size: 0.9rem;
 }
 
 .error-summary h4 {
-	color: var(--danger-color);
+	color: var(--danger);
 	margin-bottom: 0.5rem;
 }
 
-/* --- Scrollbar Styles --- */
-/* For Webkit browsers (Chrome, Safari, Edge) */
+.site-footer {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	flex-wrap: wrap;
+	padding: 1rem 1.5rem 1.5rem;
+	color: var(--text-muted);
+	font-size: 0.8rem;
+}
+
+.site-footer a {
+	color: var(--accent);
+	text-decoration: none;
+}
+
+.site-footer a:hover {
+	text-decoration: underline;
+}
+
+.toast {
+	position: fixed;
+	bottom: 1.25rem;
+	left: 50%;
+	transform: translateX(-50%) translateY(12px);
+	background: var(--bg-elevated);
+	border: 1px solid var(--line);
+	color: var(--text);
+	padding: 0.7rem 1rem;
+	border-radius: var(--radius);
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		opacity 0.2s ease,
+		transform 0.2s ease;
+	z-index: 1100;
+	font-size: 0.9rem;
+}
+
+.toast.visible {
+	opacity: 1;
+	transform: translateX(-50%) translateY(0);
+}
+
 ::-webkit-scrollbar {
 	width: 10px;
 	height: 10px;
 }
 
 ::-webkit-scrollbar-track {
-	background: var(--background-color);
+	background: var(--bg-deep);
 }
 
 ::-webkit-scrollbar-thumb {
-	background-color: var(--border-color);
+	background-color: var(--line);
 	border-radius: 10px;
-	border: 2px solid var(--background-color);
+	border: 2px solid var(--bg-deep);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-	background-color: var(--accent-color);
+	background-color: var(--accent-dim);
 }
 
-/* For Firefox */
 * {
 	scrollbar-width: thin;
-	scrollbar-color: var(--border-color) var(--background-color);
+	scrollbar-color: var(--line) var(--bg-deep);
 }
 
-.footer-credit {
-	position: fixed;
-	bottom: 1rem;
-	left: 1rem;
-	font-size: 0.8rem;
-	color: var(--text-muted);
-	opacity: 0.7;
-	transition: opacity 0.3s ease;
-	z-index: 1;
-}
-
-.footer-credit:hover {
-	opacity: 1;
-}
-
-.footer-credit a {
-	color: var(--accent-color);
-	text-decoration: none;
-}
-
-.footer-credit a:hover {
-	text-decoration: underline;
-}
-
-#creator-credit {
-	left: auto;
-	right: 1rem;
-	text-align: right;
-}
-
-/* --- Responsive Design --- */
 @media (max-width: 768px) {
-	h1 {
-		font-size: 2rem;
+	.brand-mark {
+		font-size: 2.6rem;
 	}
 
 	.container {
-		padding: 1rem;
+		padding: 1.25rem 1rem 3rem;
 	}
 
-	.duration-options {
+	.duration-options,
+	.config-stats {
 		grid-template-columns: 1fr;
 	}
 
 	.dns-name {
-		width: 100px;
-		font-size: 0.9rem;
+		width: 88px;
+		font-size: 0.85rem;
 	}
 
 	.latency-value {
-		width: 60px;
-		font-size: 0.9rem;
+		width: 58px;
+		font-size: 0.8rem;
 	}
 
-	.modal-content {
-		width: 95%;
-		margin: 1rem;
+	.graph-footer {
+		flex-direction: column;
+		align-items: stretch;
 	}
 
-	.modal-body {
-		padding: 1.5rem;
+	.graph-footer .action-button,
+	.graph-footer-actions {
+		width: 100%;
+	}
+
+	.graph-footer-actions .edit-btn {
+		flex: 1;
 	}
 
 	.modal-footer {
-		padding: 1rem;
 		flex-direction: column;
 	}
 
@@ -947,27 +1272,27 @@ th:hover .tooltip {
 		width: 100%;
 	}
 
-	.comparison-table {
-		font-size: 0.9rem;
-	}
-
-	.comparison-table th,
-	.comparison-table td {
-		padding: 0.5rem;
-	}
-
-	.footer-credit {
-		position: static;
+	.site-footer {
+		flex-direction: column;
 		text-align: center;
-		padding: 1rem 0;
+		justify-content: center;
 	}
 
 	.latency-pair {
-		min-width: 140px;
-		gap: 0.5rem;
+		min-width: 120px;
 	}
 
 	.latency-pair .detailed-latency {
-		width: 60px;
+		width: 56px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
 	}
 }

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#0b1016"/>
+  <path d="M14 34h8l4-12 6 24 5-16 3 8h10" stroke="#3dd6c6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="46" cy="20" r="5" fill="#3dd6c6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 			aria-labelledby="duration-title"
 			aria-hidden="true"
 			hidden
+			inert
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -98,6 +99,7 @@
 			aria-labelledby="config-title"
 			aria-hidden="true"
 			hidden
+			inert
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -171,6 +173,7 @@
 			aria-labelledby="providers-title"
 			aria-hidden="true"
 			hidden
+			inert
 		>
 			<div class="modal-content modal-wide">
 				<div class="modal-header">
@@ -213,6 +216,7 @@
 			aria-labelledby="domains-title"
 			aria-hidden="true"
 			hidden
+			inert
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -255,6 +259,7 @@
 			aria-labelledby="help-title"
 			aria-hidden="true"
 			hidden
+			inert
 		>
 			<div class="modal-content">
 				<div class="modal-header">

--- a/index.html
+++ b/index.html
@@ -2,76 +2,229 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>DNS Bench Pro — Find your fastest DNS</title>
 		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1.0"
+			name="description"
+			content="Client-side DNS-over-HTTPS benchmark. Compare resolver latency, reliability, and cached vs uncached performance from your browser — privately."
 		/>
-		<title>DNSBench Pro</title>
+		<meta property="og:title" content="DNS Bench Pro" />
+		<meta
+			property="og:description"
+			content="Find the fastest DNS resolver from where you are. Private, browser-only DoH benchmarks."
+		/>
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://dnsbenchpro.netlify.app" />
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="DNS Bench Pro" />
+		<meta
+			name="twitter:description"
+			content="Find the fastest DNS resolver from where you are."
+		/>
+		<link rel="icon" href="favicon.svg" type="image/svg+xml" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap"
+			rel="stylesheet"
+		/>
 		<link rel="stylesheet" href="css/style.css" />
 	</head>
 	<body>
-		<!-- Duration Modal -->
-		<div id="duration-modal" class="modal-overlay">
+		<a class="skip-link" href="#main">Skip to content</a>
+
+		<!-- Duration / profile modal -->
+		<div
+			id="duration-modal"
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="duration-title"
+			aria-hidden="true"
+		>
 			<div class="modal-content">
 				<div class="modal-header">
-					<h3>Select Test Profile</h3>
+					<h3 id="duration-title">Select test profile</h3>
+					<p class="modal-subtitle">
+						More queries means steadier averages and a longer run.
+					</p>
 				</div>
 				<div class="modal-body">
 					<div class="duration-options">
-						<button class="duration-btn" data-queries="3">
-							Quick Test <span>3 queries/url</span>
+						<button
+							type="button"
+							class="duration-btn"
+							data-queries="3"
+							data-initial-focus
+						>
+							<span class="duration-label">Quick</span>
+							<span class="duration-meta">3 queries/url</span>
+							<span class="duration-estimate" data-estimate>~30s</span>
+							<span class="duration-hint">Best for a fast check</span>
 						</button>
-						<button class="duration-btn" data-queries="6">
-							Standard Test <span>6 queries/url</span>
+						<button type="button" class="duration-btn" data-queries="6">
+							<span class="duration-label">Balanced</span>
+							<span class="duration-meta">6 queries/url</span>
+							<span class="duration-estimate" data-estimate>~1 min</span>
+							<span class="duration-hint">Recommended default</span>
 						</button>
-						<button class="duration-btn" data-queries="18">
-							Extended Test <span>18 queries/url</span>
+						<button type="button" class="duration-btn" data-queries="18">
+							<span class="duration-label">Thorough</span>
+							<span class="duration-meta">18 queries/url</span>
+							<span class="duration-estimate" data-estimate>~3 min</span>
+							<span class="duration-hint">More stable medians</span>
 						</button>
-						<button class="duration-btn" data-queries="36">
-							Comprehensive <span>36 queries/url</span>
+						<button type="button" class="duration-btn" data-queries="36">
+							<span class="duration-label">Comprehensive</span>
+							<span class="duration-meta">36 queries/url</span>
+							<span class="duration-estimate" data-estimate>~6 min</span>
+							<span class="duration-hint">Highest confidence</span>
 						</button>
 					</div>
+				</div>
+				<div class="modal-footer">
+					<button
+						type="button"
+						class="modal-btn secondary"
+						id="cancel-duration-btn"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Config modal -->
+		<div
+			id="config-modal"
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="config-title"
+			aria-hidden="true"
+		>
+			<div class="modal-content">
+				<div class="modal-header">
+					<h3 id="config-title">Configure benchmark</h3>
+					<p class="modal-subtitle">
+						Choose providers and sites before you run.
+					</p>
+				</div>
+				<div class="modal-body">
+					<div class="config-stats">
+						<div class="config-stat">
+							<span class="config-stat-value" id="config-providers-count"
+								>6</span
+							>
+							<span class="config-stat-label">Providers</span>
+						</div>
+						<div class="config-stat">
+							<span class="config-stat-value" id="config-domains-count"
+								>6</span
+							>
+							<span class="config-stat-label">Sites</span>
+						</div>
+					</div>
+
+					<div class="preset-row" role="group" aria-label="Presets">
+						<button type="button" class="preset-btn" data-preset="default">
+							Default
+						</button>
+						<button type="button" class="preset-btn" data-preset="privacy">
+							Privacy
+						</button>
+						<button type="button" class="preset-btn" data-preset="minimal">
+							Minimal
+						</button>
+						<button type="button" class="preset-btn ghost" id="reset-defaults-btn">
+							Reset
+						</button>
+					</div>
+
+					<div class="config-actions">
+						<button
+							type="button"
+							class="modal-btn secondary"
+							id="open-providers-from-config"
+						>
+							Edit providers
+						</button>
+						<button
+							type="button"
+							class="modal-btn secondary"
+							id="open-domains-from-config"
+						>
+							Edit sites
+						</button>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="modal-btn primary" id="close-config-btn">
+						Done
+					</button>
 				</div>
 			</div>
 		</div>
 
 		<!-- Edit Providers Modal -->
-		<div id="edit-providers-modal" class="modal-overlay">
-			<div class="modal-content">
+		<div
+			id="edit-providers-modal"
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="providers-title"
+			aria-hidden="true"
+		>
+			<div class="modal-content modal-wide">
 				<div class="modal-header">
-					<h3>Edit DNS Providers</h3>
+					<h3 id="providers-title">Edit DNS providers</h3>
 				</div>
 				<div class="modal-body">
+					<p id="providers-error" class="form-error" hidden></p>
 					<div class="edit-form">
 						<div id="providers-list"></div>
-						<button class="add-provider-btn" id="add-provider-btn">
-							+ Add Provider
+						<button type="button" class="add-provider-btn" id="add-provider-btn">
+							+ Add provider
 						</button>
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button class="modal-btn secondary" id="cancel-providers-btn">
+					<button
+						type="button"
+						class="modal-btn secondary"
+						id="cancel-providers-btn"
+					>
 						Cancel
 					</button>
-					<button class="modal-btn primary" id="save-providers-btn">
-						Save Changes
+					<button
+						type="button"
+						class="modal-btn primary"
+						id="save-providers-btn"
+					>
+						Save changes
 					</button>
 				</div>
 			</div>
 		</div>
 
 		<!-- Edit Domains Modal -->
-		<div id="edit-domains-modal" class="modal-overlay">
+		<div
+			id="edit-domains-modal"
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="domains-title"
+			aria-hidden="true"
+		>
 			<div class="modal-content">
 				<div class="modal-header">
-					<h3>Edit Test Domains</h3>
+					<h3 id="domains-title">Edit test domains</h3>
 				</div>
 				<div class="modal-body">
+					<p id="domains-error" class="form-error" hidden></p>
 					<div class="edit-form">
 						<div class="form-group">
-							<label for="domains-textarea">
-								Domains to test (one per line):
-							</label>
+							<label for="domains-textarea">Domains to test (one per line)</label>
 							<textarea
 								id="domains-textarea"
 								rows="10"
@@ -81,164 +234,260 @@
 					</div>
 				</div>
 				<div class="modal-footer">
-					<button class="modal-btn secondary" id="cancel-domains-btn">
+					<button
+						type="button"
+						class="modal-btn secondary"
+						id="cancel-domains-btn"
+					>
 						Cancel
 					</button>
-					<button class="modal-btn primary" id="save-domains-btn">
-						Save Changes
+					<button type="button" class="modal-btn primary" id="save-domains-btn">
+						Save changes
 					</button>
 				</div>
 			</div>
 		</div>
 
-		<div id="start-screen">
-			<div class="container">
-				<h1>DNSBench Pro</h1>
-				<p
-					style="
-						margin-bottom: 2rem;
-						color: var(--text-muted);
-						font-size: 1.1rem;
-					"
-				>
-					Test and compare DNS resolver performance, reliability, and
-					features.
-				</p>
-				<button id="start-button" class="action-button">
-					Start Test
-				</button>
+		<!-- Help modal -->
+		<div
+			id="help-modal"
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="help-title"
+			aria-hidden="true"
+		>
+			<div class="modal-content">
+				<div class="modal-header">
+					<h3 id="help-title">How DNS Bench Pro works</h3>
+				</div>
+				<div class="modal-body help-body">
+					<section>
+						<h4>DNS-over-HTTPS (DoH)</h4>
+						<p>
+							Instead of classic DNS on port 53, this tool sends encrypted DNS
+							queries over HTTPS to each resolver’s DoH endpoint — from
+							<strong>your browser</strong>, on <strong>your network</strong>.
+						</p>
+					</section>
+					<section>
+						<h4>Warm-up</h4>
+						<p>
+							Before timing starts, we send untimed probes so TCP/TLS handshakes
+							don’t inflate the first real measurements.
+						</p>
+					</section>
+					<section>
+						<h4>Cached vs uncached</h4>
+						<p>
+							The first query for each domain uses a random subdomain (cold /
+							uncached path). Later queries hit the same domain and usually show
+							faster, cache-warmed responses.
+						</p>
+					</section>
+					<section>
+						<h4>Privacy</h4>
+						<p>
+							There is no server-side logging from this site. Queries go from your
+							browser to the DNS providers you choose. Results stay on your
+							device unless you export or share them.
+						</p>
+					</section>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="modal-btn primary" id="close-help-btn">
+						Got it
+					</button>
+				</div>
 			</div>
 		</div>
 
-		<div id="results-screen">
-			<div class="container">
-				<section id="recommendation-section" style="display: none">
-					<div id="recommendation-card">
-						<h3>Top Recommendation</h3>
-						<p id="recommendation-text"></p>
-					</div>
-				</section>
-
-				<section id="main-graph-section">
-					<h2>
-						<svg
-							class="icon"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							fill="currentColor"
+		<main id="main">
+			<div id="start-screen">
+				<div class="atmosphere" aria-hidden="true"></div>
+				<div class="container start-container">
+					<p class="brand-mark">DNS Bench Pro</p>
+					<p class="start-tagline">
+						Find the fastest DNS resolver from where you are.
+					</p>
+					<p class="start-privacy">
+						Private by design — all measurements run in your browser.
+					</p>
+					<div class="start-actions">
+						<button id="start-button" class="action-button" type="button">
+							Start test
+						</button>
+						<button
+							id="configure-button"
+							class="ghost-button"
+							type="button"
 						>
-							<path
-								d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z"
-							/>
-						</svg>
-						Overall Performance
-					</h2>
-					<div id="status-text" class="status-text"></div>
-					<div id="progress-indicator" class="progress-indicator"></div>
-					<div id="main-graph-container">
-						<div id="main-graph-bars"></div>
-						<div class="graph-footer">
-							<div class="graph-footer-actions">
-								<button class="edit-btn" id="edit-providers-btn">
-									Edit Providers
-								</button>
-								<button class="edit-btn" id="edit-domains-btn">
-									Edit Sites
+							Configure
+						</button>
+						<button id="help-button" class="text-button" type="button">
+							How it works
+						</button>
+					</div>
+					<p id="config-summary" class="config-summary">
+						6 providers · 6 sites
+					</p>
+				</div>
+			</div>
+
+			<div id="results-screen">
+				<div class="container">
+					<section
+						id="results-hero"
+						class="results-hero"
+						data-mode="progress"
+						aria-live="polite"
+					>
+						<div id="hero-progress">
+							<div class="progress-head">
+								<p id="progress-phase" class="progress-phase">Ready</p>
+								<p id="progress-percent" class="progress-percent">0%</p>
+							</div>
+							<div
+								class="progress-track"
+								role="progressbar"
+								aria-valuemin="0"
+								aria-valuemax="100"
+								aria-labelledby="progress-phase"
+							>
+								<div id="progress-bar-fill" class="progress-bar-fill"></div>
+							</div>
+							<p id="status-text" class="status-text"></p>
+							<p id="progress-indicator" class="progress-indicator"></p>
+							<p id="progress-live" class="sr-only" aria-live="polite"></p>
+							<div class="hero-actions">
+								<button
+									type="button"
+									id="stop-test-button"
+									class="danger-button"
+									hidden
+								>
+									Stop test
 								</button>
 							</div>
-							<button
-								id="run-again-button"
-								class="action-button"
-							>
-								Run Again
-							</button>
 						</div>
-					</div>
-					<div
-						id="error-summary"
-						class="error-summary"
-						style="display: none"
-					>
-						<h4>Connection Issues Detected</h4>
-						<div id="error-details"></div>
-					</div>
-				</section>
 
-				<section id="detailed-breakdown-section">
-					<h2>
-						<svg
-							class="icon"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-						>
-							<path
-								d="M12 3C6.486 3 2 7.486 2 13s4.486 10 10 10 10-4.486 10-10S17.514 3 12 3zm0 18c-4.411 0-8-3.589-8-8s3.589-8 8-8 8 3.589 8 8-3.589 8-8 8z"
-							/>
-							<path
-								d="M13 7h-2v5.414l3.293 3.293 1.414-1.414L13 11.586z"
-							/>
-						</svg>
-						Detailed Breakdown
-					</h2>
-					<div id="detailed-graphs-container"></div>
-				</section>
+						<div id="hero-recommendation" hidden>
+							<p class="hero-eyebrow">Top recommendation</p>
+							<div id="recommendation-meta" class="recommendation-meta"></div>
+							<p id="recommendation-text" class="recommendation-text"></p>
+						</div>
+					</section>
 
-				<section id="comparison-section">
-					<h2>
-						<svg
-							class="icon"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							fill="currentColor"
-						>
-							<path
-								d="M12 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm0 18c-4.411 0-8-3.589-8-8s3.589-8 8-8 8 3.589 8 8-3.589 8-8 8z"
-							/>
-							<path
-								d="m14.239 8.3-4.48 1.92-1.92 4.48 4.48-1.92 1.92-4.48z"
-							/>
-						</svg>
-						Comprehensive Comparison
-					</h2>
-					<div class="comparison-container">
-						<div id="comparison-content">
-							<p
-								style="
-									text-align: center;
-									color: var(--text-muted);
-								"
-							>
-								Run a test to see detailed comparison data
+					<!-- Legacy hook kept hidden for compatibility -->
+					<section id="recommendation-section" hidden></section>
+
+					<section id="main-graph-section">
+						<div class="section-heading">
+							<h2>Overall performance</h2>
+							<p class="section-note">
+								Live average latency while providers are measured. Lower is
+								better.
+							</p>
+							<p class="legend">
+								<span class="legend-item cached">Cached</span>
+								<span class="legend-item uncached">Uncached</span>
 							</p>
 						</div>
-					</div>
-				</section>
+						<div id="main-graph-container">
+							<div id="main-graph-bars"></div>
+							<div class="graph-footer">
+								<div class="graph-footer-actions">
+									<button
+										type="button"
+										class="edit-btn"
+										id="edit-providers-btn"
+									>
+										Edit providers
+									</button>
+									<button type="button" class="edit-btn" id="edit-domains-btn">
+										Edit sites
+									</button>
+								</div>
+								<button
+									type="button"
+									id="run-again-button"
+									class="action-button"
+								>
+									Run again
+								</button>
+							</div>
+						</div>
+						<div
+							id="error-summary"
+							class="error-summary"
+							style="display: none"
+						>
+							<h4>Connection issues detected</h4>
+							<div id="error-details"></div>
+						</div>
+					</section>
 
-				<div id="controls-area">
-					<button
-						id="export-csv-button"
-						class="secondary-action-button"
-						style="display: none"
-					>
-						Export to CSV
-					</button>
+					<section id="detailed-breakdown-section" class="secondary-section">
+						<div class="section-heading">
+							<h2>Detailed breakdown</h2>
+							<p class="section-note">
+								Per-domain cached vs uncached averages for each resolver.
+							</p>
+						</div>
+						<div id="detailed-graphs-container"></div>
+					</section>
+
+					<section id="comparison-section" class="secondary-section">
+						<div class="section-heading">
+							<h2>Comparison</h2>
+							<p class="section-note">
+								Rank reflects median finish order. Sorting changes row order
+								only.
+							</p>
+						</div>
+						<div class="comparison-container">
+							<div id="comparison-content">
+								<p class="empty-state">
+									Results will appear here after a full run.
+								</p>
+							</div>
+						</div>
+					</section>
+
+					<div id="controls-area">
+						<button
+							type="button"
+							id="share-results-button"
+							class="secondary-action-button"
+							style="display: none"
+						>
+							Share results
+						</button>
+						<button
+							type="button"
+							id="export-csv-button"
+							class="secondary-action-button"
+							style="display: none"
+						>
+							Export to CSV
+						</button>
+					</div>
 				</div>
 			</div>
-		</div>
+		</main>
 
-		<div class="footer-credit">
-			Inspired by
-			<a
-				href="https://github.com/BrainicHQ/DoHSpeedTest"
-				target="_blank"
-				rel="noopener noreferrer"
-				>DoHSpeedTest by BrainicHQ</a
-			>
-		</div>
-		<div class="footer-credit" id="creator-credit">
-			Created by Socheat Rotanak
-		</div>
+		<footer class="site-footer">
+			<p>
+				Inspired by
+				<a
+					href="https://github.com/BrainicHQ/DoHSpeedTest"
+					target="_blank"
+					rel="noopener noreferrer"
+					>DoHSpeedTest by BrainicHQ</a
+				>
+			</p>
+			<p id="creator-credit">Created by Socheat Rotanak</p>
+		</footer>
 
 		<script src="js/main.js" type="module"></script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@
 			content="Find the fastest DNS resolver from where you are."
 		/>
 		<link rel="icon" href="favicon.svg" type="image/svg+xml" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap"
-			rel="stylesheet"
-		/>
 		<link rel="stylesheet" href="css/style.css" />
 	</head>
 	<body>
@@ -41,6 +35,7 @@
 			aria-modal="true"
 			aria-labelledby="duration-title"
 			aria-hidden="true"
+			hidden
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -102,6 +97,7 @@
 			aria-modal="true"
 			aria-labelledby="config-title"
 			aria-hidden="true"
+			hidden
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -174,6 +170,7 @@
 			aria-modal="true"
 			aria-labelledby="providers-title"
 			aria-hidden="true"
+			hidden
 		>
 			<div class="modal-content modal-wide">
 				<div class="modal-header">
@@ -215,6 +212,7 @@
 			aria-modal="true"
 			aria-labelledby="domains-title"
 			aria-hidden="true"
+			hidden
 		>
 			<div class="modal-content">
 				<div class="modal-header">
@@ -256,6 +254,7 @@
 			aria-modal="true"
 			aria-labelledby="help-title"
 			aria-hidden="true"
+			hidden
 		>
 			<div class="modal-content">
 				<div class="modal-header">

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -1,0 +1,115 @@
+// Shared modal accessibility helpers.
+
+let previouslyFocused = null;
+let activeModal = null;
+let trapHandler = null;
+let keyHandler = null;
+
+function getFocusable(container) {
+	return [
+		...container.querySelectorAll(
+			'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+		),
+	].filter(
+		(el) =>
+			el.offsetParent !== null ||
+			el === document.activeElement ||
+			getComputedStyle(el).position === "fixed",
+	);
+}
+
+function clearListeners() {
+	if (trapHandler) document.removeEventListener("keydown", trapHandler);
+	if (keyHandler) document.removeEventListener("keydown", keyHandler);
+	trapHandler = null;
+	keyHandler = null;
+}
+
+export function openModal(modal, { initialFocus, retainFocus = false } = {}) {
+	if (!modal) return;
+
+	const switching = activeModal && activeModal !== modal;
+	const refreshing = activeModal === modal;
+
+	if (switching) {
+		closeModal(activeModal);
+	}
+
+	if (!refreshing) {
+		previouslyFocused = document.activeElement;
+	}
+
+	activeModal = modal;
+	modal.classList.add("visible");
+	modal.setAttribute("aria-hidden", "false");
+
+	const focusables = getFocusable(modal);
+	const focusTarget =
+		initialFocus ||
+		modal.querySelector("[data-initial-focus]") ||
+		focusables[0] ||
+		modal.querySelector(".modal-content");
+
+	if (!retainFocus || !refreshing) {
+		requestAnimationFrame(() => {
+			if (focusTarget && typeof focusTarget.focus === "function") {
+				focusTarget.focus();
+			}
+		});
+	}
+
+	clearListeners();
+
+	trapHandler = (e) => {
+		if (e.key !== "Tab" || !activeModal) return;
+		const items = getFocusable(activeModal);
+		if (items.length === 0) {
+			e.preventDefault();
+			return;
+		}
+		const first = items[0];
+		const last = items[items.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	};
+
+	keyHandler = (e) => {
+		if (e.key === "Escape" && activeModal) {
+			e.preventDefault();
+			closeModal(activeModal);
+		}
+	};
+
+	document.addEventListener("keydown", trapHandler);
+	document.addEventListener("keydown", keyHandler);
+}
+
+export function closeModal(modal) {
+	const target = modal || activeModal;
+	if (!target) return;
+
+	target.classList.remove("visible");
+	target.setAttribute("aria-hidden", "true");
+
+	if (activeModal === target) {
+		clearListeners();
+		activeModal = null;
+
+		if (
+			previouslyFocused &&
+			typeof previouslyFocused.focus === "function"
+		) {
+			previouslyFocused.focus();
+		}
+		previouslyFocused = null;
+	}
+}
+
+export function getActiveModal() {
+	return activeModal;
+}

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -41,6 +41,7 @@ export function openModal(modal, { initialFocus, retainFocus = false } = {}) {
 
 	activeModal = modal;
 	modal.hidden = false;
+	modal.inert = false;
 	modal.classList.add("visible");
 	modal.setAttribute("aria-hidden", "false");
 
@@ -96,6 +97,7 @@ export function closeModal(modal) {
 
 	target.classList.remove("visible");
 	target.hidden = true;
+	target.inert = true;
 	target.setAttribute("aria-hidden", "true");
 
 	if (activeModal === target) {

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -40,6 +40,7 @@ export function openModal(modal, { initialFocus, retainFocus = false } = {}) {
 	}
 
 	activeModal = modal;
+	modal.hidden = false;
 	modal.classList.add("visible");
 	modal.setAttribute("aria-hidden", "false");
 
@@ -94,6 +95,7 @@ export function closeModal(modal) {
 	if (!target) return;
 
 	target.classList.remove("visible");
+	target.hidden = true;
 	target.setAttribute("aria-hidden", "true");
 
 	if (activeModal === target) {

--- a/js/api.js
+++ b/js/api.js
@@ -1,18 +1,13 @@
-// frontend/js/api.js
-// Handles client-side testing logic.
+// Client-side testing helpers.
 
 import { measureDohLatency } from "./doh.js";
+import { getAbortSignal } from "./config.js";
 
 /**
- * Sends a single, untimed query to a provider.
- * The purpose is to establish a TCP/TLS connection so that the first
- * "real" test isn't slowed down by initial connection overhead.
- * The result of this query is intentionally ignored.
+ * Untimed probe to establish TCP/TLS so the first timed query isn't cold.
  */
 export async function warmUpConnection(provider, domain) {
-	// This sends a query just to establish a connection.
-	// It does not affect the 'queriedDomains' set used in the main test.
-	await measureDohLatency(provider, domain);
+	await measureDohLatency(provider, domain, getAbortSignal());
 }
 
 export async function measureLatency(provider, domain, isUncached) {
@@ -20,12 +15,15 @@ export async function measureLatency(provider, domain, isUncached) {
 		? `${Math.random().toString(36).substring(7)}.${domain}`
 		: domain;
 
-	// Pass the entire provider object, not just the URL
-	const latency = await measureDohLatency(provider, domainToQuery);
+	const latency = await measureDohLatency(
+		provider,
+		domainToQuery,
+		getAbortSignal(),
+	);
 
 	return {
-		latency: latency,
-		dnssecSupported: Math.random() > 0.1, // Still simulating this for UI
+		latency,
+		dnssecSupported: Math.random() > 0.1,
 		error: latency === null ? "failed" : null,
 	};
 }

--- a/js/config.js
+++ b/js/config.js
@@ -118,12 +118,12 @@ export const PRESETS = {
 const state = {
 	providers: DEFAULT_PROVIDERS.map((p) => ({ ...p })),
 	domains: [...DEFAULT_DOMAINS],
-	providerColors: {},
+	providerColors: Object.create(null),
 	isTestRunning: false,
-	allProviderStats: {},
+	allProviderStats: Object.create(null),
 	queriedDomains: new Set(),
 	runPhase: "idle", // idle | warmup | measure | complete | cancelled
-	medianRanks: {},
+	medianRanks: Object.create(null),
 	lastQueryCount: null,
 	abortController: null,
 };
@@ -134,6 +134,19 @@ export function getState() {
 
 function cloneProviders(providers) {
 	return providers.map((p) => ({ ...p }));
+}
+
+function makeUniqueProviderName(name, usedNames) {
+	let candidate = name;
+	let suffix = 2;
+
+	while (usedNames.has(candidate.toLowerCase())) {
+		candidate = `${name} (${suffix})`;
+		suffix++;
+	}
+
+	usedNames.add(candidate.toLowerCase());
+	return candidate;
 }
 
 function knownProviderMeta(url) {
@@ -151,6 +164,8 @@ function knownProviderMeta(url) {
 }
 
 export function normalizeProviders(providers) {
+	const usedNames = new Set();
+
 	return providers
 		.map((p) => {
 			const name = (p.name || "").trim();
@@ -158,7 +173,7 @@ export function normalizeProviders(providers) {
 			if (!name || !url) return null;
 			const meta = knownProviderMeta(url);
 			return {
-				name,
+				name: makeUniqueProviderName(name, usedNames),
 				url,
 				type: p.type || meta.type,
 				allowCors:
@@ -255,7 +270,7 @@ export function generateProviderColors() {
 		"#f368e0",
 		"#ff9f43",
 	];
-	state.providerColors = {};
+	state.providerColors = Object.create(null);
 	state.providers.forEach(({ name }, index) => {
 		state.providerColors[name] =
 			predefinedColors[index % predefinedColors.length];

--- a/js/config.js
+++ b/js/config.js
@@ -1,103 +1,289 @@
-// frontend/js/config.js
 // Manages application state, default settings, and persistence.
 
-// API_BASE is no longer needed.
 export const MAX_LATENCY = 150; // For graph scaling
 
-// Default state, can be overridden by localStorage
+export const DEFAULT_PROVIDERS = [
+	{
+		name: "Cloudflare",
+		url: "https://1.1.1.1/dns-query",
+		type: "post",
+		allowCors: true,
+	},
+	{
+		name: "Google",
+		url: "https://dns.google/dns-query",
+		type: "post",
+		allowCors: false,
+	},
+	{
+		name: "Quad9",
+		url: "https://dns.quad9.net/dns-query",
+		type: "post",
+		allowCors: false,
+	},
+	{
+		name: "OpenDNS",
+		url: "https://doh.opendns.com/dns-query",
+		type: "post",
+		allowCors: false,
+	},
+	{
+		name: "AdGuard DNS",
+		url: "https://dns.adguard-dns.com/dns-query",
+		type: "post",
+		allowCors: false,
+	},
+	{
+		name: "ControlD",
+		url: "https://freedns.controld.com/p2",
+		type: "post",
+		allowCors: false,
+	},
+];
+
+export const DEFAULT_DOMAINS = [
+	"google.com",
+	"youtube.com",
+	"facebook.com",
+	"reddit.com",
+	"instagram.com",
+	"x.com",
+];
+
+export const PRESETS = {
+	default: {
+		label: "Default",
+		description: "Popular public resolvers and common sites",
+		providers: DEFAULT_PROVIDERS,
+		domains: DEFAULT_DOMAINS,
+	},
+	privacy: {
+		label: "Privacy-focused",
+		description: "Resolvers known for privacy and blocking",
+		providers: [
+			{
+				name: "Quad9",
+				url: "https://dns.quad9.net/dns-query",
+				type: "post",
+				allowCors: false,
+			},
+			{
+				name: "AdGuard DNS",
+				url: "https://dns.adguard-dns.com/dns-query",
+				type: "post",
+				allowCors: false,
+			},
+			{
+				name: "ControlD",
+				url: "https://freedns.controld.com/p2",
+				type: "post",
+				allowCors: false,
+			},
+			{
+				name: "Cloudflare",
+				url: "https://1.1.1.1/dns-query",
+				type: "post",
+				allowCors: true,
+			},
+		],
+		domains: ["google.com", "wikipedia.org", "reddit.com", "github.com"],
+	},
+	minimal: {
+		label: "Minimal",
+		description: "Faster run with fewer providers and sites",
+		providers: [
+			{
+				name: "Cloudflare",
+				url: "https://1.1.1.1/dns-query",
+				type: "post",
+				allowCors: true,
+			},
+			{
+				name: "Google",
+				url: "https://dns.google/dns-query",
+				type: "post",
+				allowCors: false,
+			},
+			{
+				name: "Quad9",
+				url: "https://dns.quad9.net/dns-query",
+				type: "post",
+				allowCors: false,
+			},
+		],
+		domains: ["google.com", "youtube.com", "cloudflare.com"],
+	},
+};
+
 const state = {
-	// Updated provider list with DNS.SB removed
-	providers: [
-		{
-			name: "Cloudflare",
-			url: "https://1.1.1.1/dns-query",
-			type: "post",
-			allowCors: true, // Cloudflare supports CORS
-		},
-		{
-			name: "Google",
-			url: "https://dns.google/dns-query",
-			type: "post",
-			allowCors: false, // Google does not
-		},
-		{
-			name: "Quad9",
-			url: "https://dns.quad9.net/dns-query",
-			type: "post",
-			allowCors: false,
-		},
-		{
-			name: "OpenDNS",
-			url: "https://doh.opendns.com/dns-query",
-			type: "post",
-			allowCors: false,
-		},
-		{
-			name: "AdGuard DNS",
-			url: "https://dns.adguard-dns.com/dns-query",
-			type: "post",
-			allowCors: false,
-		},
-		{
-			name: "ControlD",
-			url: "https://freedns.controld.com/p2",
-			type: "post",
-			allowCors: false,
-		},
-	],
-	// Updated default list of websites to test
-	domains: [
-		"google.com",
-		"youtube.com",
-		"facebook.com",
-		"reddit.com",
-		"instagram.com",
-		"x.com", // Updated from twitter.com
-	],
+	providers: DEFAULT_PROVIDERS.map((p) => ({ ...p })),
+	domains: [...DEFAULT_DOMAINS],
 	providerColors: {},
 	isTestRunning: false,
 	allProviderStats: {},
 	queriedDomains: new Set(),
+	runPhase: "idle", // idle | warmup | measure | complete | cancelled
+	medianRanks: {},
+	lastQueryCount: null,
+	abortController: null,
 };
 
 export function getState() {
 	return state;
 }
 
-// This function saves the user's custom lists to their browser's localStorage.
-export function saveSettings() {
-	localStorage.setItem("dnsBenchProviders", JSON.stringify(state.providers));
-	localStorage.setItem("dnsBenchDomains", JSON.stringify(state.domains));
+function cloneProviders(providers) {
+	return providers.map((p) => ({ ...p }));
 }
 
-// This function loads the user's custom lists when they revisit the page.
-// If no custom lists are found, it uses the default lists defined above.
+function knownProviderMeta(url) {
+	const match = DEFAULT_PROVIDERS.find((p) => p.url === url);
+	if (match) {
+		return { type: match.type, allowCors: match.allowCors };
+	}
+	for (const preset of Object.values(PRESETS)) {
+		const found = preset.providers.find((p) => p.url === url);
+		if (found) {
+			return { type: found.type, allowCors: found.allowCors };
+		}
+	}
+	return { type: "post", allowCors: false };
+}
+
+export function normalizeProviders(providers) {
+	return providers
+		.map((p) => {
+			const name = (p.name || "").trim();
+			const url = (p.url || "").trim();
+			if (!name || !url) return null;
+			const meta = knownProviderMeta(url);
+			return {
+				name,
+				url,
+				type: p.type || meta.type,
+				allowCors:
+					typeof p.allowCors === "boolean" ? p.allowCors : meta.allowCors,
+			};
+		})
+		.filter(Boolean);
+}
+
+export function saveSettings() {
+	try {
+		localStorage.setItem(
+			"dnsBenchProviders",
+			JSON.stringify(state.providers),
+		);
+		localStorage.setItem("dnsBenchDomains", JSON.stringify(state.domains));
+	} catch {
+		/* ignore storage failures (private mode / unavailable) */
+	}
+}
+
 export function loadSettings() {
-	const savedProviders = localStorage.getItem("dnsBenchProviders");
-	const savedDomains = localStorage.getItem("dnsBenchDomains");
+	let savedProviders = null;
+	let savedDomains = null;
+	try {
+		savedProviders = localStorage.getItem("dnsBenchProviders");
+		savedDomains = localStorage.getItem("dnsBenchDomains");
+	} catch {
+		return;
+	}
 	if (savedProviders) {
-		state.providers = JSON.parse(savedProviders);
+		try {
+			state.providers = normalizeProviders(JSON.parse(savedProviders));
+			if (state.providers.length === 0) {
+				state.providers = cloneProviders(DEFAULT_PROVIDERS);
+			}
+		} catch {
+			state.providers = cloneProviders(DEFAULT_PROVIDERS);
+		}
 	}
 	if (savedDomains) {
-		state.domains = JSON.parse(savedDomains);
+		try {
+			const domains = JSON.parse(savedDomains).filter(
+				(d) => typeof d === "string" && d.trim().length > 0,
+			);
+			if (domains.length > 0) state.domains = domains;
+		} catch {
+			state.domains = [...DEFAULT_DOMAINS];
+		}
 	}
+}
+
+export function resetSettings() {
+	state.providers = cloneProviders(DEFAULT_PROVIDERS);
+	state.domains = [...DEFAULT_DOMAINS];
+	saveSettings();
+	generateProviderColors();
+}
+
+export function applyPreset(presetId) {
+	const preset = PRESETS[presetId];
+	if (!preset) return false;
+	state.providers = cloneProviders(preset.providers);
+	state.domains = [...preset.domains];
+	saveSettings();
+	generateProviderColors();
+	return true;
+}
+
+export function estimateTestDuration(queryCount) {
+	const providers = state.providers.length;
+	const domains = state.domains.length;
+	const warmUps = providers * domains;
+	const measures = providers * domains * queryCount;
+	// ~120ms per warm-up attempt + ~150ms per measure (incl. delay) + gaps
+	const seconds = Math.round((warmUps * 0.12 + measures * 0.18 + providers * 0.5));
+	if (seconds < 45) return `~${Math.max(15, seconds)}s`;
+	if (seconds < 120) return `~${Math.round(seconds / 15) * 15}s`;
+	const minutes = seconds / 60;
+	if (minutes < 3) return `~${minutes.toFixed(1)} min`;
+	return `~${Math.round(minutes)} min`;
 }
 
 export function generateProviderColors() {
 	const predefinedColors = [
-		"#ff6b6b",
-		"#4ecdc4",
-		"#45b7d1",
-		"#96ceb4",
-		"#feca57",
-		"#ff9ff3",
+		"#e86a6a",
+		"#3dd6c6",
+		"#5aa9e6",
+		"#6ecf8e",
+		"#e6a756",
+		"#c084fc",
 		"#54a0ff",
-		"#5f27cd",
+		"#7dd3c0",
 		"#f368e0",
 		"#ff9f43",
 	];
+	state.providerColors = {};
 	state.providers.forEach(({ name }, index) => {
 		state.providerColors[name] =
 			predefinedColors[index % predefinedColors.length];
 	});
+}
+
+export function createAbortController() {
+	if (state.abortController) {
+		try {
+			state.abortController.abort();
+		} catch {
+			/* ignore */
+		}
+	}
+	state.abortController = new AbortController();
+	return state.abortController;
+}
+
+export function getAbortSignal() {
+	return state.abortController ? state.abortController.signal : undefined;
+}
+
+export function abortActiveRequests() {
+	if (state.abortController) {
+		try {
+			state.abortController.abort();
+		} catch {
+			/* ignore */
+		}
+	}
 }

--- a/js/doh.js
+++ b/js/doh.js
@@ -1,6 +1,5 @@
-// frontend/js/doh.js
+// DNS wire format + DoH latency measurement.
 
-// createDnsQuery is only needed for POST requests.
 function createDnsQuery(domain) {
 	if (!domain || typeof domain !== "string") {
 		throw new Error("Invalid domain");
@@ -45,17 +44,25 @@ function createDnsQuery(domain) {
 	return new Uint8Array(buffer);
 }
 
-export async function measureDohLatency(provider, domain) {
+export async function measureDohLatency(provider, domain, externalSignal) {
 	const { url, type = "post", allowCors = false } = provider;
 
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), 5000);
 
+	const onExternalAbort = () => controller.abort();
+	if (externalSignal) {
+		if (externalSignal.aborted) {
+			clearTimeout(timeoutId);
+			return null;
+		}
+		externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+	}
+
 	try {
 		const startTime = performance.now();
 		let fetchPromise;
 
-		// --- FIX: Handle GET and POST methods separately ---
 		if (type === "get") {
 			const urlWithParams = new URL(url);
 			urlWithParams.searchParams.append("name", domain);
@@ -66,7 +73,6 @@ export async function measureDohLatency(provider, domain) {
 				signal: controller.signal,
 			});
 		} else {
-			// Default to POST
 			const queryMessage = createDnsQuery(domain);
 			const fetchOptions = {
 				method: "POST",
@@ -90,8 +96,12 @@ export async function measureDohLatency(provider, domain) {
 
 		const endTime = performance.now();
 		return endTime - startTime;
-	} catch (error) {
+	} catch {
 		clearTimeout(timeoutId);
 		return null;
+	} finally {
+		if (externalSignal) {
+			externalSignal.removeEventListener("abort", onExternalAbort);
+		}
 	}
 }

--- a/js/dom.js
+++ b/js/dom.js
@@ -1,26 +1,43 @@
-// frontend/js/dom.js
-// Centralizes all DOM element selections for easy access and maintenance.
+// Centralizes DOM element selections.
 
 export const startScreen = document.getElementById("start-screen");
 export const startButton = document.getElementById("start-button");
+export const configureButton = document.getElementById("configure-button");
+export const helpButton = document.getElementById("help-button");
+export const configSummary = document.getElementById("config-summary");
 export const runAgainButton = document.getElementById("run-again-button");
+export const stopTestButton = document.getElementById("stop-test-button");
 export const exportCsvButton = document.getElementById("export-csv-button");
+export const shareResultsButton = document.getElementById(
+	"share-results-button",
+);
 export const resultsScreen = document.getElementById("results-screen");
+export const resultsHero = document.getElementById("results-hero");
+export const heroProgress = document.getElementById("hero-progress");
+export const heroRecommendation = document.getElementById(
+	"hero-recommendation",
+);
+export const recommendationText = document.getElementById(
+	"recommendation-text",
+);
+export const recommendationMeta = document.getElementById(
+	"recommendation-meta",
+);
 export const statusText = document.getElementById("status-text");
 export const progressIndicator = document.getElementById("progress-indicator");
+export const progressBarFill = document.getElementById("progress-bar-fill");
+export const progressPhase = document.getElementById("progress-phase");
+export const progressPercent = document.getElementById("progress-percent");
+export const progressLive = document.getElementById("progress-live");
 export const mainGraphContainer = document.getElementById("main-graph-bars");
 export const detailedGraphsContainer = document.getElementById(
 	"detailed-graphs-container",
 );
 export const errorSummary = document.getElementById("error-summary");
 export const errorDetails = document.getElementById("error-details");
-export const connectionStatus = document.getElementById("connection-status");
 export const comparisonContent = document.getElementById("comparison-content");
 export const recommendationSection = document.getElementById(
 	"recommendation-section",
-);
-export const recommendationText = document.getElementById(
-	"recommendation-text",
 );
 
 // Modals
@@ -29,8 +46,10 @@ export const editProvidersModal = document.getElementById(
 	"edit-providers-modal",
 );
 export const editDomainsModal = document.getElementById("edit-domains-modal");
+export const helpModal = document.getElementById("help-modal");
+export const configModal = document.getElementById("config-modal");
 
-// Modal Controls
+// Modal controls
 export const editProvidersBtn = document.getElementById("edit-providers-btn");
 export const editDomainsBtn = document.getElementById("edit-domains-btn");
 export const providersList = document.getElementById("providers-list");
@@ -42,3 +61,23 @@ export const cancelProvidersBtn = document.getElementById(
 export const domainsTextarea = document.getElementById("domains-textarea");
 export const saveDomainsBtn = document.getElementById("save-domains-btn");
 export const cancelDomainsBtn = document.getElementById("cancel-domains-btn");
+export const cancelDurationBtn = document.getElementById("cancel-duration-btn");
+export const closeHelpBtn = document.getElementById("close-help-btn");
+export const providersError = document.getElementById("providers-error");
+export const domainsError = document.getElementById("domains-error");
+export const durationEstimates = document.querySelectorAll("[data-estimate]");
+export const presetButtons = document.querySelectorAll("[data-preset]");
+export const resetDefaultsBtn = document.getElementById("reset-defaults-btn");
+export const openProvidersFromConfig = document.getElementById(
+	"open-providers-from-config",
+);
+export const openDomainsFromConfig = document.getElementById(
+	"open-domains-from-config",
+);
+export const closeConfigBtn = document.getElementById("close-config-btn");
+export const configProvidersCount = document.getElementById(
+	"config-providers-count",
+);
+export const configDomainsCount = document.getElementById(
+	"config-domains-count",
+);

--- a/js/main.js
+++ b/js/main.js
@@ -84,7 +84,7 @@ async function runTestForProvider(provider, queriesPerUrl, progressOffset, total
 		}
 	}
 
-	if (!state.isTestRunning) return;
+	if (allResults.length === 0) return;
 
 	const allStats = stats.calculateStats(allResults);
 	state.allProviderStats[provider.name] = allStats;
@@ -171,14 +171,14 @@ async function startTest(queryCount) {
 	state.isTestRunning = true;
 	state.runPhase = "warmup";
 	state.lastQueryCount = queryCount;
-	state.medianRanks = {};
+	state.medianRanks = Object.create(null);
 	createAbortController();
 
 	dom.startScreen.classList.add("hidden");
 	dom.resultsScreen.classList.add("visible");
 	ui.setRunningControls(true);
 
-	state.allProviderStats = {};
+	state.allProviderStats = Object.create(null);
 	state.queriedDomains.clear();
 	ui.createInitialUI();
 	ui.setHeroMode("progress");

--- a/js/main.js
+++ b/js/main.js
@@ -1,21 +1,26 @@
-// frontend/js/main.js
-// The main application entry point and orchestrator.
+// Application entry point and test orchestrator.
 
 import * as dom from "./dom.js";
 import * as ui from "./ui.js";
 import * as api from "./api.js";
 import * as stats from "./stats.js";
-import { initModals } from "./modals.js";
+import { initModals, openDurationModal } from "./modals.js";
 import {
 	getState,
 	loadSettings,
 	generateProviderColors,
+	createAbortController,
+	abortActiveRequests,
 } from "./config.js";
 
-/**
- * SEQUENTIAL TEST FUNCTION - Tests one provider at a time
- */
-async function runTestForProvider(provider, queriesPerUrl) {
+function progressTotals(queryCount) {
+	const state = getState();
+	const warmUps = state.providers.length * state.domains.length;
+	const measures = state.providers.length * state.domains.length * queryCount;
+	return { warmUps, measures, overall: warmUps + measures };
+}
+
+async function runTestForProvider(provider, queriesPerUrl, progressOffset, totals) {
 	const state = getState();
 	const allResults = [];
 	let runningTotalLatency = 0;
@@ -23,11 +28,10 @@ async function runTestForProvider(provider, queriesPerUrl) {
 
 	const totalQueries = queriesPerUrl * state.domains.length;
 	let currentQueryIndex = 0;
+	const providerIndex =
+		state.providers.findIndex((p) => p.name === provider.name) + 1;
 
-	console.log(
-		`🎯 Starting test for ${provider.name} with ${queriesPerUrl} queries per URL. Total: ${totalQueries}`,
-	);
-	ui.showStatus(`Testing ${provider.name}...`);
+	ui.showStatus(`Testing ${provider.name}…`);
 
 	for (const domain of state.domains) {
 		if (!state.isTestRunning) break;
@@ -36,17 +40,18 @@ async function runTestForProvider(provider, queriesPerUrl) {
 			if (!state.isTestRunning) break;
 
 			currentQueryIndex++;
-			ui.showProgress(
-				`${provider.name}: Query ${currentQueryIndex}/${totalQueries} - ${domain}`,
-			);
+			const overallIndex = progressOffset + currentQueryIndex;
+
+			ui.setProgress({
+				phase: "Measuring",
+				label: `${provider.name} (${providerIndex}/${state.providers.length})`,
+				detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain}`,
+				overallIndex,
+				overallTotal: totals.overall,
+			});
 
 			const isUncached = i === 0;
-
-			const result = await api.measureLatency(
-				provider,
-				domain,
-				isUncached,
-			);
+			const result = await api.measureLatency(provider, domain, isUncached);
 			allResults.push({ ...result, isUncached, domain });
 
 			if (result.latency !== null) {
@@ -56,15 +61,23 @@ async function runTestForProvider(provider, queriesPerUrl) {
 					runningTotalLatency / successfulQueryCount;
 				ui.updateMainGraph(provider.name, runningAverage);
 
-				ui.showProgress(
-					`${provider.name}: Query ${currentQueryIndex}/${totalQueries} - ${domain} (${result.latency.toFixed(
+				ui.setProgress({
+					phase: "Measuring",
+					label: `${provider.name} (${providerIndex}/${state.providers.length})`,
+					detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain} · ${result.latency.toFixed(
 						0,
-					)} ms)`,
-				);
+					)} ms`,
+					overallIndex,
+					overallTotal: totals.overall,
+				});
 			} else {
-				ui.showProgress(
-					`${provider.name}: Query ${currentQueryIndex}/${totalQueries} - ${domain} (Failed)`,
-				);
+				ui.setProgress({
+					phase: "Measuring",
+					label: `${provider.name} (${providerIndex}/${state.providers.length})`,
+					detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain} · failed`,
+					overallIndex,
+					overallTotal: totals.overall,
+				});
 			}
 
 			await new Promise((resolve) => setTimeout(resolve, 100));
@@ -111,123 +124,211 @@ async function runTestForProvider(provider, queriesPerUrl) {
 	}
 
 	ui.displayDetailedBreakdown(provider.name, finalBreakdown);
-
-	console.log(`📊 ${provider.name} completed:`, {
-		overallAverage: allStats.average.toFixed(1) + "ms",
-		median: allStats.median.toFixed(1) + "ms",
-		stdDev: allStats.stdDev.toFixed(1) + "ms",
-	});
 }
 
-async function warmUpAllProviders() {
+async function warmUpAllProviders(totals) {
 	const state = getState();
-	console.log("🔥🔥🔥 Starting comprehensive warm-up phase...");
-	ui.showStatus("Warming up DNS connections...");
+	state.runPhase = "warmup";
+	ui.setProgress({
+		phase: "Warm-up",
+		label: "Priming DNS connections…",
+		detail: "So the first measurements aren’t slowed by cold starts.",
+		overallIndex: 0,
+		overallTotal: totals.overall,
+	});
 
 	let warmUpCount = 0;
-	const totalWarmUps = state.providers.length * state.domains.length;
 
 	for (const provider of state.providers) {
 		for (const domain of state.domains) {
 			if (!getState().isTestRunning) return;
 			warmUpCount++;
-			ui.showProgress(`Warming up: ${warmUpCount} / ${totalWarmUps}`);
+			ui.setProgress({
+				phase: "Warm-up",
+				label: "Priming DNS connections…",
+				detail: `${provider.name} · ${domain} (${warmUpCount}/${totals.warmUps})`,
+				overallIndex: warmUpCount,
+				overallTotal: totals.overall,
+			});
 			await api.warmUpConnection(provider, domain);
 		}
 	}
-	console.log("✅ Warm-up phase complete.");
+}
+
+function stopTest() {
+	const state = getState();
+	if (!state.isTestRunning) return;
+	state.isTestRunning = false;
+	state.runPhase = "cancelled";
+	abortActiveRequests();
+	ui.showStatus("Stopping…");
 }
 
 async function startTest(queryCount) {
 	const state = getState();
 	if (state.isTestRunning) return;
 
-	console.log(
-		"🚀 Starting DNS benchmark with providers:",
-		state.providers.map((p) => p.name),
-	);
-	console.log("🌐 Testing domains:", state.domains);
-	console.log("🔢 Queries per URL:", queryCount);
-
 	state.isTestRunning = true;
+	state.runPhase = "warmup";
+	state.lastQueryCount = queryCount;
+	state.medianRanks = {};
+	createAbortController();
+
 	dom.startScreen.classList.add("hidden");
 	dom.resultsScreen.classList.add("visible");
-	dom.runAgainButton.disabled = true;
+	ui.setRunningControls(true);
 
 	state.allProviderStats = {};
 	state.queriedDomains.clear();
 	ui.createInitialUI();
+	ui.setHeroMode("progress");
+
+	const totals = progressTotals(queryCount);
 
 	try {
-		await warmUpAllProviders();
+		await warmUpAllProviders(totals);
 
 		if (state.isTestRunning) {
+			state.runPhase = "measure";
+			let measureOffset = totals.warmUps;
+
 			for (let i = 0; i < state.providers.length; i++) {
 				if (!state.isTestRunning) break;
 
 				const provider = state.providers[i];
-				await runTestForProvider(provider, queryCount);
+				await runTestForProvider(
+					provider,
+					queryCount,
+					measureOffset,
+					totals,
+				);
+				measureOffset += state.domains.length * queryCount;
 
-				if (i < state.providers.length - 1) {
+				if (i < state.providers.length - 1 && state.isTestRunning) {
 					await new Promise((resolve) => setTimeout(resolve, 500));
 				}
 			}
 		}
 
-		if (state.isTestRunning) {
-			console.log("🎉 All tests completed successfully");
-			ui.showStatus("Test complete. See comparison table below.");
-			ui.showProgress("");
-			ui.createComparisonTable(state.allProviderStats);
+		const completedProviders = Object.keys(state.allProviderStats).length;
+		const expectedProviders = state.providers.length;
 
-			const recommendation = stats.getRecommendation(state.allProviderStats);
-			ui.displayRecommendation(recommendation);
+		if (state.isTestRunning && completedProviders === expectedProviders) {
+			state.runPhase = "complete";
+			ui.setProgress({
+				phase: "Complete",
+				label: "Test complete",
+				detail: "See recommendation and comparison below.",
+				overallIndex: totals.overall,
+				overallTotal: totals.overall,
+			});
 
-			dom.exportCsvButton.style.display = "inline-block";
-		} else {
-			console.log("⏹️ Test was cancelled");
-			ui.showStatus("Test cancelled.");
-			ui.showProgress("");
+			state.medianRanks = stats.getMedianRanks(state.allProviderStats);
+			ui.createComparisonTable(
+				state.allProviderStats,
+				state.medianRanks,
+			);
+
+			const recommendation = stats.getRecommendation(
+				state.allProviderStats,
+			);
+			ui.displayRecommendation(recommendation, false);
+
+			dom.exportCsvButton.style.display = "inline-flex";
+			if (dom.shareResultsButton) {
+				dom.shareResultsButton.style.display = "inline-flex";
+			}
+		} else if (state.runPhase === "cancelled" || !state.isTestRunning) {
+			state.runPhase = "cancelled";
+			ui.setProgress({
+				phase: "Stopped",
+				label: "Test stopped",
+				detail: "Partial results are shown where available.",
+				overallIndex: 0,
+				overallTotal: 1,
+			});
+
+			if (completedProviders > 0) {
+				state.medianRanks = stats.getMedianRanks(
+					state.allProviderStats,
+				);
+				ui.createComparisonTable(
+					state.allProviderStats,
+					state.medianRanks,
+				);
+				const recommendation = stats.getRecommendation(
+					state.allProviderStats,
+				);
+				if (recommendation) {
+					ui.displayRecommendation(recommendation, true);
+				} else {
+					ui.showIncompleteState(
+						"<strong>Test stopped.</strong> Not enough data for a recommendation.",
+					);
+				}
+				dom.exportCsvButton.style.display = "inline-flex";
+				if (dom.shareResultsButton) {
+					dom.shareResultsButton.style.display = "inline-flex";
+				}
+			} else {
+				ui.showIncompleteState(
+					"<strong>Test stopped</strong> before any provider finished.",
+				);
+			}
 		}
 	} catch (error) {
-		console.error("💥 Error during test execution:", error);
-		ui.showStatus("Test failed due to an error. Check console for details.");
-		ui.showProgress("");
+		console.error("Error during test execution:", error);
+		ui.showStatus("Test failed due to an error. Check the console.");
+		ui.setProgress({
+			phase: "Error",
+			label: "Test failed",
+			detail: "See console for details.",
+			overallIndex: 0,
+			overallTotal: 1,
+		});
 	}
 
-	dom.runAgainButton.disabled = false;
+	ui.setRunningControls(false);
 	state.isTestRunning = false;
 }
 
 function initialize() {
-	console.log("🎬 Initializing DNSBench Pro");
 	loadSettings();
 	generateProviderColors();
+	ui.updateConfigSummary();
 	dom.startButton.disabled = false;
-	initModals(startTest);
+	initModals(startTest, stopTest);
 
-	// FIX: Updated "Run Again" button logic
 	dom.runAgainButton.addEventListener("click", () => {
-		console.log("🔄 Preparing for new test from results screen.");
-
-		// Reset UI elements to their initial state before showing the modal
 		ui.createInitialUI();
-		dom.recommendationSection.style.display = "none";
+		if (dom.recommendationSection) {
+			dom.recommendationSection.style.display = "none";
+		}
 		dom.exportCsvButton.style.display = "none";
-		dom.comparisonContent.innerHTML = `<p style="text-align: center; color: var(--text-muted);">Run a test to see detailed comparison data</p>`;
-		dom.statusText.textContent = "";
-		dom.progressIndicator.textContent = "";
-
-		// Open the test selection modal directly
-		dom.durationModal.classList.add("visible");
+		if (dom.shareResultsButton) {
+			dom.shareResultsButton.style.display = "none";
+		}
+		dom.comparisonContent.innerHTML = `<p class="empty-state">Results will appear here after a full run.</p>`;
+		ui.setHeroMode("progress");
+		ui.setProgress({
+			phase: "Ready",
+			label: "Choose a test profile to begin.",
+			detail: "",
+			overallIndex: 0,
+			overallTotal: 1,
+		});
+		openDurationModal();
 	});
 
 	dom.exportCsvButton.addEventListener("click", () => {
-		console.log("📁 Exporting CSV");
 		ui.exportToCSV(getState().allProviderStats);
 	});
 
-	console.log("✅ DNSBench Pro initialized");
+	if (dom.shareResultsButton) {
+		dom.shareResultsButton.addEventListener("click", () => {
+			ui.shareResults();
+		});
+	}
 }
 
 document.addEventListener("DOMContentLoaded", initialize);

--- a/js/modals.js
+++ b/js/modals.js
@@ -240,6 +240,7 @@ export function initModals(startTestCallback, stopTestCallback) {
 	].forEach((modal) => {
 		if (!modal) return;
 		modal.hidden = true;
+		modal.inert = true;
 		modal.setAttribute("aria-hidden", "true");
 		modal.addEventListener("click", (e) => {
 			if (e.target === modal) closeModal(modal);

--- a/js/modals.js
+++ b/js/modals.js
@@ -14,6 +14,8 @@ import {
 	PRESETS,
 } from "./config.js";
 
+let providerDraft = null;
+
 function isValidHttpsUrl(value) {
 	try {
 		const url = new URL(value);
@@ -24,18 +26,51 @@ function isValidHttpsUrl(value) {
 }
 
 function isValidDomain(value) {
-	return /^(?=.{1,253}$)(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(value.trim());
+	const domain = value.trim();
+	if (domain.length < 1 || domain.length > 253) return false;
+
+	const labels = domain.split(".");
+	return (
+		labels.length >= 2 &&
+		labels.every(
+			(label) =>
+				label.length >= 1 &&
+				label.length <= 63 &&
+				/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label),
+		)
+	);
 }
 
 function openEditProviders() {
 	const state = getState();
+	providerDraft = state.providers.map((provider) => ({ ...provider }));
+	renderEditProviders();
+}
+
+function syncProviderDraftFromInputs() {
+	if (!providerDraft) return;
+
+	const valuesByIndex = {};
+	document.querySelectorAll(".provider-item input").forEach((item) => {
+		const index = Number(item.dataset.index);
+		if (!valuesByIndex[index]) valuesByIndex[index] = {};
+		valuesByIndex[index][item.dataset.field] = item.value;
+	});
+
+	providerDraft = providerDraft.map((provider, index) => ({
+		...provider,
+		...(valuesByIndex[index] || {}),
+	}));
+}
+
+function renderEditProviders() {
 	dom.providersList.innerHTML = "";
 	if (dom.providersError) {
 		dom.providersError.hidden = true;
 		dom.providersError.textContent = "";
 	}
 
-	state.providers.forEach((provider, index) => {
+	(providerDraft || []).forEach((provider, index) => {
 		const div = document.createElement("div");
 		div.className = "provider-item";
 		div.innerHTML = `
@@ -61,14 +96,19 @@ function openEditProviders() {
         `;
 		dom.providersList.appendChild(div);
 	});
-	openModal(dom.editProvidersModal, { retainFocus: true });
+	openModal(dom.editProvidersModal);
 }
 
 function escapeAttr(value) {
-	return String(value || "")
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/</g, "&lt;");
+	const entities = {
+		"&": "&amp;",
+		"<": "&lt;",
+		">": "&gt;",
+		'"': "&quot;",
+		"'": "&#39;",
+	};
+
+	return String(value || "").replace(/[&<>"']/g, (character) => entities[character]);
 }
 
 function openEditDomains() {
@@ -106,6 +146,16 @@ function saveProviders() {
 		}
 	});
 
+	const seenNames = new Set();
+	draft.forEach((provider) => {
+		if (!provider.name) return;
+		const key = provider.name.toLowerCase();
+		if (seenNames.has(key)) {
+			errors.push(`Provider names must be unique: ${provider.name}`);
+		}
+		seenNames.add(key);
+	});
+
 	if (errors.length) {
 		if (dom.providersError) {
 			dom.providersError.hidden = false;
@@ -131,6 +181,7 @@ function saveProviders() {
 	saveSettings();
 	generateProviderColors();
 	ui.updateConfigSummary();
+	providerDraft = null;
 	closeModal(dom.editProvidersModal);
 }
 
@@ -188,6 +239,7 @@ export function initModals(startTestCallback, stopTestCallback) {
 		dom.configModal,
 	].forEach((modal) => {
 		if (!modal) return;
+		modal.hidden = true;
 		modal.setAttribute("aria-hidden", "true");
 		modal.addEventListener("click", (e) => {
 			if (e.target === modal) closeModal(modal);
@@ -222,27 +274,29 @@ export function initModals(startTestCallback, stopTestCallback) {
 	dom.providersList.addEventListener("click", (e) => {
 		const removeButton = e.target.closest(".remove-provider-btn");
 		if (removeButton) {
-			const state = getState();
+			syncProviderDraftFromInputs();
 			const index = parseInt(removeButton.dataset.index, 10);
-			state.providers.splice(index, 1);
-			openEditProviders();
+			providerDraft.splice(index, 1);
+			renderEditProviders();
 		}
 	});
 
 	dom.addProviderBtn.addEventListener("click", () => {
-		getState().providers.push({
+		syncProviderDraftFromInputs();
+		providerDraft.push({
 			name: "",
 			url: "",
 			type: "post",
 			allowCors: false,
 		});
-		openEditProviders();
+		renderEditProviders();
 	});
 
 	dom.saveProvidersBtn.addEventListener("click", saveProviders);
-	dom.cancelProvidersBtn.addEventListener("click", () =>
-		closeModal(dom.editProvidersModal),
-	);
+	dom.cancelProvidersBtn.addEventListener("click", () => {
+		providerDraft = null;
+		closeModal(dom.editProvidersModal);
+	});
 
 	if (dom.editDomainsBtn) {
 		dom.editDomainsBtn.addEventListener("click", openEditDomains);

--- a/js/modals.js
+++ b/js/modals.js
@@ -1,60 +1,87 @@
-// frontend/js/modals.js
-// Manages the logic and event handling for all modals.
+// Modal logic: profiles, config, providers, domains, help.
 
 import * as dom from "./dom.js";
-import { getState, saveSettings, generateProviderColors } from "./config.js";
+import * as ui from "./ui.js";
+import { openModal, closeModal } from "./a11y.js";
+import {
+	getState,
+	saveSettings,
+	generateProviderColors,
+	normalizeProviders,
+	applyPreset,
+	resetSettings,
+	estimateTestDuration,
+	PRESETS,
+} from "./config.js";
 
-function openModal(modal) {
-	modal.classList.add("visible");
+function isValidHttpsUrl(value) {
+	try {
+		const url = new URL(value);
+		return url.protocol === "https:";
+	} catch {
+		return false;
+	}
 }
 
-function closeModal(modal) {
-	modal.classList.remove("visible");
+function isValidDomain(value) {
+	return /^(?=.{1,253}$)(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(value.trim());
 }
 
 function openEditProviders() {
 	const state = getState();
 	dom.providersList.innerHTML = "";
+	if (dom.providersError) {
+		dom.providersError.hidden = true;
+		dom.providersError.textContent = "";
+	}
+
 	state.providers.forEach((provider, index) => {
 		const div = document.createElement("div");
 		div.className = "provider-item";
-		// --- FIX: Replaced simple inputs with a structured, labeled layout ---
 		div.innerHTML = `
             <div class="provider-inputs">
                 <div class="form-group">
                     <label for="provider-name-${index}">Provider Name</label>
-                    <input id="provider-name-${index}" type="text" placeholder="e.g., Cloudflare" value="${
-			provider.name
-		}" data-index="${index}" data-field="name">
+                    <input id="provider-name-${index}" type="text" placeholder="e.g., Cloudflare" value="${escapeAttr(
+						provider.name,
+					)}" data-index="${index}" data-field="name">
                 </div>
                 <div class="form-group">
                     <label for="provider-url-${index}">DoH URL</label>
-                    <input id="provider-url-${index}" type="text" placeholder="https://..." value="${
-			provider.url
-		}" data-index="${index}" data-field="url">
+                    <input id="provider-url-${index}" type="url" placeholder="https://..." value="${escapeAttr(
+						provider.url,
+					)}" data-index="${index}" data-field="url">
                 </div>
             </div>
-            <button class="remove-provider-btn" data-index="${index}" title="Remove Provider">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <button type="button" class="remove-provider-btn" data-index="${index}" title="Remove Provider" aria-label="Remove provider">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
                 </svg>
             </button>
         `;
 		dom.providersList.appendChild(div);
 	});
-	openModal(dom.editProvidersModal);
+	openModal(dom.editProvidersModal, { retainFocus: true });
+}
+
+function escapeAttr(value) {
+	return String(value || "")
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;");
 }
 
 function openEditDomains() {
 	const state = getState();
 	dom.domainsTextarea.value = state.domains.join("\n");
+	if (dom.domainsError) {
+		dom.domainsError.hidden = true;
+		dom.domainsError.textContent = "";
+	}
 	openModal(dom.editDomainsModal);
 }
 
 function saveProviders() {
-	const state = getState();
-	const newProviders = [];
-	// This selector still works with the new structure
 	const items = document.querySelectorAll(".provider-item input");
 	const providerData = {};
 
@@ -64,45 +91,109 @@ function saveProviders() {
 		providerData[index][item.dataset.field] = item.value.trim();
 	});
 
-	for (const index in providerData) {
-		const { name, url } = providerData[index];
-		if (name && url) {
-			newProviders.push({ name, url });
-		}
+	const draft = Object.values(providerData);
+	const errors = [];
+
+	if (draft.length === 0) {
+		errors.push("Add at least one provider.");
 	}
 
-	if (newProviders.length > 0) {
-		state.providers = newProviders;
-		saveSettings();
-		generateProviderColors();
-		closeModal(dom.editProvidersModal);
+	draft.forEach((p, i) => {
+		if (!p.name) errors.push(`Provider ${i + 1}: name is required.`);
+		if (!p.url) errors.push(`Provider ${i + 1}: DoH URL is required.`);
+		else if (!isValidHttpsUrl(p.url)) {
+			errors.push(`Provider ${i + 1}: URL must be https://`);
+		}
+	});
+
+	if (errors.length) {
+		if (dom.providersError) {
+			dom.providersError.hidden = false;
+			dom.providersError.textContent = errors[0];
+		}
+		return;
 	}
+
+	const state = getState();
+	const previousByUrl = Object.fromEntries(
+		state.providers.map((p) => [p.url, p]),
+	);
+	const normalized = normalizeProviders(
+		draft.map((p) => ({
+			...p,
+			...(previousByUrl[p.url] || {}),
+			name: p.name,
+			url: p.url,
+		})),
+	);
+
+	state.providers = normalized;
+	saveSettings();
+	generateProviderColors();
+	ui.updateConfigSummary();
+	closeModal(dom.editProvidersModal);
 }
 
 function saveDomains() {
-	const state = getState();
 	const domains = dom.domainsTextarea.value
 		.split("\n")
 		.map((d) => d.trim())
 		.filter((d) => d.length > 0);
-	if (domains.length > 0) {
-		state.domains = domains;
-		saveSettings();
-		closeModal(dom.editDomainsModal);
+
+	const errors = [];
+	if (domains.length === 0) {
+		errors.push("Add at least one domain.");
 	}
+	const invalid = domains.find((d) => !isValidDomain(d));
+	if (invalid) {
+		errors.push(`Invalid domain: ${invalid}`);
+	}
+
+	if (errors.length) {
+		if (dom.domainsError) {
+			dom.domainsError.hidden = false;
+			dom.domainsError.textContent = errors[0];
+		}
+		return;
+	}
+
+	const state = getState();
+	state.domains = domains;
+	saveSettings();
+	ui.updateConfigSummary();
+	closeModal(dom.editDomainsModal);
 }
 
-export function initModals(startTestCallback) {
-	// General modal close behavior
-	[dom.durationModal, dom.editProvidersModal, dom.editDomainsModal].forEach(
-		(modal) => {
-			modal.addEventListener("click", (e) => {
-				if (e.target === modal) closeModal(modal);
-			});
-		},
-	);
+function openConfigModal() {
+	ui.updateConfigSummary();
+	openModal(dom.configModal);
+}
 
-	// Duration modal
+function openDurationModal() {
+	ui.refreshDurationEstimates(estimateTestDuration);
+	openModal(dom.durationModal);
+}
+
+function canStart() {
+	const state = getState();
+	return state.providers.length > 0 && state.domains.length > 0;
+}
+
+export function initModals(startTestCallback, stopTestCallback) {
+	[
+		dom.durationModal,
+		dom.editProvidersModal,
+		dom.editDomainsModal,
+		dom.helpModal,
+		dom.configModal,
+	].forEach((modal) => {
+		if (!modal) return;
+		modal.setAttribute("aria-hidden", "true");
+		modal.addEventListener("click", (e) => {
+			if (e.target === modal) closeModal(modal);
+		});
+	});
+
 	dom.durationModal.addEventListener("click", (e) => {
 		const button = e.target.closest(".duration-btn");
 		if (button) {
@@ -112,36 +203,131 @@ export function initModals(startTestCallback) {
 		}
 	});
 
-	// Edit Providers modal
-	dom.editProvidersBtn.addEventListener("click", openEditProviders);
+	if (dom.cancelDurationBtn) {
+		dom.cancelDurationBtn.addEventListener("click", () =>
+			closeModal(dom.durationModal),
+		);
+	}
+
+	if (dom.editProvidersBtn) {
+		dom.editProvidersBtn.addEventListener("click", openEditProviders);
+	}
+	if (dom.openProvidersFromConfig) {
+		dom.openProvidersFromConfig.addEventListener("click", () => {
+			closeModal(dom.configModal);
+			openEditProviders();
+		});
+	}
+
 	dom.providersList.addEventListener("click", (e) => {
-		// --- FIX: Use .closest() for a more robust click target ---
 		const removeButton = e.target.closest(".remove-provider-btn");
 		if (removeButton) {
 			const state = getState();
 			const index = parseInt(removeButton.dataset.index, 10);
 			state.providers.splice(index, 1);
-			openEditProviders(); // Refresh list
+			openEditProviders();
 		}
 	});
+
 	dom.addProviderBtn.addEventListener("click", () => {
-		getState().providers.push({ name: "", url: "" });
+		getState().providers.push({
+			name: "",
+			url: "",
+			type: "post",
+			allowCors: false,
+		});
 		openEditProviders();
 	});
+
 	dom.saveProvidersBtn.addEventListener("click", saveProviders);
 	dom.cancelProvidersBtn.addEventListener("click", () =>
 		closeModal(dom.editProvidersModal),
 	);
 
-	// Edit Domains modal
-	dom.editDomainsBtn.addEventListener("click", openEditDomains);
+	if (dom.editDomainsBtn) {
+		dom.editDomainsBtn.addEventListener("click", openEditDomains);
+	}
+	if (dom.openDomainsFromConfig) {
+		dom.openDomainsFromConfig.addEventListener("click", () => {
+			closeModal(dom.configModal);
+			openEditDomains();
+		});
+	}
+
 	dom.saveDomainsBtn.addEventListener("click", saveDomains);
 	dom.cancelDomainsBtn.addEventListener("click", () =>
 		closeModal(dom.editDomainsModal),
 	);
 
-	// Main start button
-	dom.startButton.addEventListener("click", () => {
-		if (!dom.startButton.disabled) openModal(dom.durationModal);
+	if (dom.configureButton) {
+		dom.configureButton.addEventListener("click", openConfigModal);
+	}
+	if (dom.closeConfigBtn) {
+		dom.closeConfigBtn.addEventListener("click", () =>
+			closeModal(dom.configModal),
+		);
+	}
+
+	if (dom.helpButton) {
+		dom.helpButton.addEventListener("click", () => openModal(dom.helpModal));
+	}
+	if (dom.closeHelpBtn) {
+		dom.closeHelpBtn.addEventListener("click", () =>
+			closeModal(dom.helpModal),
+		);
+	}
+
+	document.querySelectorAll("[data-preset]").forEach((btn) => {
+		btn.addEventListener("click", () => {
+			const id = btn.dataset.preset;
+			if (applyPreset(id)) {
+				ui.updateConfigSummary();
+				const preset = PRESETS[id];
+				if (dom.configSummary) {
+					showToast(`Applied ${preset.label} preset`);
+				}
+			}
+		});
 	});
+
+	if (dom.resetDefaultsBtn) {
+		dom.resetDefaultsBtn.addEventListener("click", () => {
+			resetSettings();
+			ui.updateConfigSummary();
+			showToast("Reset to defaults");
+		});
+	}
+
+	dom.startButton.addEventListener("click", () => {
+		if (dom.startButton.disabled) return;
+		if (!canStart()) {
+			showToast("Add at least one provider and one domain.");
+			openConfigModal();
+			return;
+		}
+		openDurationModal();
+	});
+
+	if (dom.stopTestButton && stopTestCallback) {
+		dom.stopTestButton.addEventListener("click", stopTestCallback);
+	}
 }
+
+function showToast(message) {
+	let toast = document.getElementById("toast");
+	if (!toast) {
+		toast = document.createElement("div");
+		toast.id = "toast";
+		toast.className = "toast";
+		toast.setAttribute("role", "status");
+		document.body.appendChild(toast);
+	}
+	toast.textContent = message;
+	toast.classList.add("visible");
+	clearTimeout(showToast._timer);
+	showToast._timer = setTimeout(() => {
+		toast.classList.remove("visible");
+	}, 2200);
+}
+
+export { openDurationModal };

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,13 +1,12 @@
-// frontend/js/stats.js
-// Contains pure functions for performing statistical calculations on test data.
+// Statistical helpers for benchmark results.
 
 export function calculateStats(results) {
 	const successful = results.filter((r) => r.latency !== null);
 	if (successful.length === 0) {
 		return {
 			average: 0,
-			median: 0, // Add median
-			stdDev: 0, // Add stdDev
+			median: 0,
+			stdDev: 0,
 			uncachedAvg: 0,
 			cachedAvg: 0,
 			reliability: 0,
@@ -28,7 +27,6 @@ export function calculateStats(results) {
 	const sum = (arr) => arr.reduce((acc, val) => acc + val, 0);
 	const average = sum(latencies) / latencies.length;
 
-	// --- FIX: Calculate Median ---
 	const sortedLatencies = [...latencies].sort((a, b) => a - b);
 	const mid = Math.floor(sortedLatencies.length / 2);
 	const median =
@@ -36,17 +34,16 @@ export function calculateStats(results) {
 			? sortedLatencies[mid]
 			: (sortedLatencies[mid - 1] + sortedLatencies[mid]) / 2;
 
-	// --- FIX: Calculate Standard Deviation ---
 	const stdDev = Math.sqrt(
 		latencies
 			.map((x) => Math.pow(x - average, 2))
-			.reduce((a, b) => a + b) / latencies.length,
+			.reduce((a, b) => a + b, 0) / latencies.length,
 	);
 
 	return {
-		average: average,
-		median: median,
-		stdDev: stdDev,
+		average,
+		median,
+		stdDev,
 		uncachedAvg: uncached.length > 0 ? sum(uncached) / uncached.length : 0,
 		cachedAvg: cached.length > 0 ? sum(cached) / cached.length : 0,
 		reliability: (successful.length / results.length) * 100,
@@ -55,15 +52,26 @@ export function calculateStats(results) {
 	};
 }
 
+export function getMedianRanks(allProviderStats) {
+	const ranked = Object.entries(allProviderStats)
+		.filter(([, stats]) => stats.count > 0)
+		.sort((a, b) => a[1].median - b[1].median);
+
+	const ranks = {};
+	ranked.forEach(([name], index) => {
+		ranks[name] = index + 1;
+	});
+	return ranks;
+}
+
 export function getRecommendation(allProviderStats) {
 	const contenders = Object.entries(allProviderStats).filter(
-		([_, stats]) => stats.count > 0,
+		([, stats]) => stats.count > 0,
 	);
 	if (contenders.length === 0) return null;
 
 	const scored = contenders
 		.map(([name, stats]) => {
-			// --- FIX: Use the more stable median for scoring ---
 			const latencyScore = stats.median;
 			const reliabilityPenalty = (100 - stats.reliability) * 10;
 			const score = latencyScore + reliabilityPenalty;
@@ -73,14 +81,59 @@ export function getRecommendation(allProviderStats) {
 
 	if (scored.length > 0) {
 		const winner = scored[0];
-		// --- FIX: Report both average and median in the recommendation ---
-		return `Based on a balance of speed and reliability, <strong>${
-			winner.name
-		}</strong> is the top performer. It showed a typical (median) response time of <strong>${winner.stats.median.toFixed(
-			0,
-		)} ms</strong> and an average of <strong>${winner.stats.average.toFixed(
-			0,
-		)} ms</strong>.`;
+		const runnerUp = scored[1];
+		let delta = "";
+		if (runnerUp) {
+			const gap = runnerUp.stats.median - winner.stats.median;
+			if (gap > 0.5) {
+				delta = ` That is <strong>${gap.toFixed(0)} ms</strong> faster (median) than ${runnerUp.name}.`;
+			}
+		}
+		return {
+			html: `Based on speed and reliability, <strong>${
+				winner.name
+			}</strong> is the top performer. Typical (median) response <strong>${winner.stats.median.toFixed(
+				0,
+			)} ms</strong>, average <strong>${winner.stats.average.toFixed(
+				0,
+			)} ms</strong>, reliability <strong>${winner.stats.reliability.toFixed(
+				0,
+			)}%</strong>.${delta}`,
+			winnerName: winner.name,
+			median: winner.stats.median,
+			average: winner.stats.average,
+			reliability: winner.stats.reliability,
+		};
 	}
 	return null;
+}
+
+export function buildShareSummary(allProviderStats, medianRanks, queryCount) {
+	const ranked = Object.entries(allProviderStats)
+		.filter(([, stats]) => stats.count > 0)
+		.sort(
+			(a, b) => (medianRanks[a[0]] || 99) - (medianRanks[b[0]] || 99),
+		);
+
+	if (ranked.length === 0) return "DNS Bench Pro — no completed results.";
+
+	const lines = [
+		"DNS Bench Pro results",
+		`Profile: ${queryCount} queries/url`,
+		`Date: ${new Date().toISOString().slice(0, 10)}`,
+		"",
+	];
+
+	ranked.forEach(([name, stats]) => {
+		lines.push(
+			`#${medianRanks[name]} ${name} — median ${stats.median.toFixed(
+				1,
+			)} ms, avg ${stats.average.toFixed(1)} ms, reliability ${stats.reliability.toFixed(
+				0,
+			)}%`,
+		);
+	});
+
+	lines.push("", "https://dnsbenchpro.netlify.app");
+	return lines.join("\n");
 }

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,5 +1,17 @@
 // Statistical helpers for benchmark results.
 
+function escapeHtml(value) {
+	const entities = {
+		"&": "&amp;",
+		"<": "&lt;",
+		">": "&gt;",
+		'"': "&quot;",
+		"'": "&#39;",
+	};
+
+	return String(value).replace(/[&<>"']/g, (character) => entities[character]);
+}
+
 export function calculateStats(results) {
 	const successful = results.filter((r) => r.latency !== null);
 	if (successful.length === 0) {
@@ -57,7 +69,7 @@ export function getMedianRanks(allProviderStats) {
 		.filter(([, stats]) => stats.count > 0)
 		.sort((a, b) => a[1].median - b[1].median);
 
-	const ranks = {};
+	const ranks = Object.create(null);
 	ranked.forEach(([name], index) => {
 		ranks[name] = index + 1;
 	});
@@ -82,16 +94,19 @@ export function getRecommendation(allProviderStats) {
 	if (scored.length > 0) {
 		const winner = scored[0];
 		const runnerUp = scored[1];
+		const winnerLabel = escapeHtml(winner.name);
 		let delta = "";
 		if (runnerUp) {
 			const gap = runnerUp.stats.median - winner.stats.median;
 			if (gap > 0.5) {
-				delta = ` That is <strong>${gap.toFixed(0)} ms</strong> faster (median) than ${runnerUp.name}.`;
+				delta = ` That is <strong>${gap.toFixed(0)} ms</strong> faster (median) than ${escapeHtml(
+					runnerUp.name,
+				)}.`;
 			}
 		}
 		return {
 			html: `Based on speed and reliability, <strong>${
-				winner.name
+				winnerLabel
 			}</strong> is the top performer. Typical (median) response <strong>${winner.stats.median.toFixed(
 				0,
 			)} ms</strong>, average <strong>${winner.stats.average.toFixed(

--- a/js/ui.js
+++ b/js/ui.js
@@ -4,6 +4,22 @@ import * as dom from "./dom.js";
 import { getState, MAX_LATENCY } from "./config.js";
 import { buildShareSummary } from "./stats.js";
 
+function escapeHtml(value) {
+	const entities = {
+		"&": "&amp;",
+		"<": "&lt;",
+		">": "&gt;",
+		'"': "&quot;",
+		"'": "&#39;",
+	};
+
+	return String(value).replace(/[&<>"']/g, (character) => entities[character]);
+}
+
+function providerKey(name) {
+	return encodeURIComponent(String(name));
+}
+
 export function updateConfigSummary() {
 	const state = getState();
 	const text = `${state.providers.length} providers · ${state.domains.length} sites`;
@@ -114,11 +130,11 @@ export function createInitialUI() {
 
 	state.providers.forEach(({ name }) => {
 		const color = state.providerColors[name];
-		const safeName = name.replace(/\s+/g, "-");
+		const safeName = providerKey(name);
 
 		dom.mainGraphContainer.innerHTML += `
             <div class="graph-bar-wrapper" id="wrapper-${safeName}">
-                <div class="dns-name">${name}</div>
+                <div class="dns-name">${escapeHtml(name)}</div>
                 <div class="bar-container">
                     <div class="bar" id="bar-${safeName}" style="background-color: ${color};"></div>
                 </div>
@@ -130,7 +146,7 @@ export function createInitialUI() {
                 <div class="card-header">
                     <div class="card-title-section">
                         <span class="card-color-dot" style="background-color: ${color};"></span>
-                        <h3 class="card-title">${name}</h3>
+                        <h3 class="card-title">${escapeHtml(name)}</h3>
                     </div>
                     <div class="card-stats" id="stats-${safeName}">Waiting…</div>
                 </div>
@@ -148,7 +164,7 @@ export function createInitialUI() {
 }
 
 export function displayDetailedBreakdown(providerName, breakdownData) {
-	const safeProviderName = providerName.replace(/\s+/g, "-");
+	const safeProviderName = providerKey(providerName);
 	const container = document.getElementById(`results-${safeProviderName}`);
 	if (!container) return;
 
@@ -174,7 +190,7 @@ export function displayDetailedBreakdown(providerName, breakdownData) {
 				: `<span class="detailed-latency na">—</span>`;
 
 		row.innerHTML = `
-            <strong class="domain-name">${domain}</strong>
+            <strong class="domain-name">${escapeHtml(domain)}</strong>
             <div class="latency-pair">
                 ${cachedAvgHtml}
                 ${uncachedAvgHtml}
@@ -185,7 +201,7 @@ export function displayDetailedBreakdown(providerName, breakdownData) {
 }
 
 export function updateMainGraph(name, latency) {
-	const safeName = name.replace(/\s+/g, "-");
+	const safeName = providerKey(name);
 	const bar = document.getElementById(`bar-${safeName}`);
 	const latencyEl = document.getElementById(`latency-${safeName}`);
 	if (bar && latencyEl) {
@@ -196,7 +212,7 @@ export function updateMainGraph(name, latency) {
 }
 
 export function updateCardStats(name, allStats) {
-	const safeName = name.replace(/\s+/g, "-");
+	const safeName = providerKey(name);
 	const statsEl = document.getElementById(`stats-${safeName}`);
 	if (statsEl && allStats.count > 0) {
 		statsEl.innerHTML = `Median: <strong>${allStats.median.toFixed(
@@ -206,7 +222,7 @@ export function updateCardStats(name, allStats) {
 }
 
 export function showCard(name) {
-	const safeName = name.replace(/\s+/g, "-");
+	const safeName = providerKey(name);
 	const card = document.getElementById(`card-${safeName}`);
 	if (card) card.classList.add("visible");
 }
@@ -260,7 +276,14 @@ export function createComparisonTable(allProviderStats, medianRanks) {
 	function attachHeaderListeners() {
 		document
 			.querySelectorAll(".comparison-table th[data-sort-key]")
-			.forEach((th) => th.addEventListener("click", handleHeaderClick));
+			.forEach((th) => {
+				th.addEventListener("click", handleHeaderClick);
+				th.addEventListener("keydown", (e) => {
+					if (e.key !== "Enter" && e.key !== " ") return;
+					e.preventDefault();
+					handleHeaderClick(e);
+				});
+			});
 	}
 
 	function renderTable() {
@@ -308,7 +331,7 @@ export function createComparisonTable(allProviderStats, medianRanks) {
 					state.providerColors[stats.name]
 				};">
                     <td><span class="rank-badge ${rankClass}">#${rank}</span></td>
-                    <td class="provider-cell">${stats.name}</td>
+                    <td class="provider-cell">${escapeHtml(stats.name)}</td>
                     <td class="emphasis">${stats.median.toFixed(1)} ms</td>
                     <td>${stats.average.toFixed(1)} ms</td>
                     <td class="cached-cell">${stats.cachedAvg.toFixed(1)} ms</td>
@@ -339,11 +362,17 @@ export function displayRecommendation(recommendation, incomplete = false) {
 		: recommendation.html;
 
 	if (dom.recommendationMeta) {
-		dom.recommendationMeta.innerHTML = `
-			<span class="meta-pill">${recommendation.winnerName}</span>
-			<span class="meta-pill">${recommendation.median.toFixed(0)} ms median</span>
-			<span class="meta-pill">${recommendation.reliability.toFixed(0)}% reliable</span>
-		`;
+		dom.recommendationMeta.replaceChildren();
+		[
+			recommendation.winnerName,
+			`${recommendation.median.toFixed(0)} ms median`,
+			`${recommendation.reliability.toFixed(0)}% reliable`,
+		].forEach((text) => {
+			const pill = document.createElement("span");
+			pill.className = "meta-pill";
+			pill.textContent = text;
+			dom.recommendationMeta.appendChild(pill);
+		});
 	}
 
 	setHeroMode("recommendation");
@@ -359,8 +388,21 @@ export function showIncompleteState(message) {
 }
 
 export function exportToCSV(allProviderStats) {
-	const headers =
-		"Provider,Avg Latency,Median Latency,Std Deviation,Uncached Avg,Cached Avg,Reliability,DNSSEC Support";
+	const escapeCsvCell = (value) => {
+		let text = String(value);
+		if (/^[=+\-@]/.test(text)) text = `'${text}`;
+		return `"${text.replace(/"/g, '""')}"`;
+	};
+	const headers = [
+		"Provider",
+		"Avg Latency",
+		"Median Latency",
+		"Std Deviation",
+		"Uncached Avg",
+		"Cached Avg",
+		"Reliability",
+		"DNSSEC Support",
+	].map(escapeCsvCell);
 	const rows = Object.entries(allProviderStats).map(([name, stats]) =>
 		[
 			name,
@@ -371,12 +413,17 @@ export function exportToCSV(allProviderStats) {
 			stats.cachedAvg.toFixed(2),
 			stats.reliability.toFixed(2),
 			stats.dnssec.toFixed(2),
-		].join(","),
+		]
+			.map(escapeCsvCell)
+			.join(","),
 	);
 
-	const csv = "data:text/csv;charset=utf-8," + [headers, ...rows].join("\n");
+	const csv = [headers.join(","), ...rows].join("\n");
 	const link = document.createElement("a");
-	link.setAttribute("href", encodeURI(csv));
+	link.setAttribute(
+		"href",
+		"data:text/csv;charset=utf-8," + encodeURIComponent(csv),
+	);
 	link.setAttribute("download", "dns_benchmark_results.csv");
 	document.body.appendChild(link);
 	link.click();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,17 +1,116 @@
-// frontend/js/ui.js
-// Manages all direct DOM manipulation and UI updates.
+// DOM rendering and UI updates.
 
 import * as dom from "./dom.js";
 import { getState, MAX_LATENCY } from "./config.js";
+import { buildShareSummary } from "./stats.js";
+
+export function updateConfigSummary() {
+	const state = getState();
+	const text = `${state.providers.length} providers · ${state.domains.length} sites`;
+	if (dom.configSummary) dom.configSummary.textContent = text;
+	if (dom.configProvidersCount) {
+		dom.configProvidersCount.textContent = String(state.providers.length);
+	}
+	if (dom.configDomainsCount) {
+		dom.configDomainsCount.textContent = String(state.domains.length);
+	}
+}
+
+export function setHeroMode(mode) {
+	// mode: progress | recommendation | idle
+	if (!dom.heroProgress || !dom.heroRecommendation) return;
+	dom.heroProgress.hidden = mode !== "progress";
+	dom.heroRecommendation.hidden = mode !== "recommendation";
+	if (dom.resultsHero) {
+		dom.resultsHero.dataset.mode = mode;
+	}
+}
+
+export function setProgress(progress) {
+	const {
+		phase = "",
+		label = "",
+		detail = "",
+		overallIndex = 0,
+		overallTotal = 1,
+	} = progress || {};
+
+	const pct = Math.min(
+		100,
+		Math.round((overallIndex / Math.max(overallTotal, 1)) * 100),
+	);
+
+	if (dom.progressPhase) {
+		dom.progressPhase.textContent = phase || "Working";
+	}
+	if (dom.statusText) {
+		dom.statusText.textContent = label;
+	}
+	if (dom.progressIndicator) {
+		dom.progressIndicator.textContent = detail;
+	}
+	if (dom.progressBarFill) {
+		dom.progressBarFill.style.width = `${pct}%`;
+		const track = dom.progressBarFill.parentElement;
+		if (track && track.getAttribute("role") === "progressbar") {
+			track.setAttribute("aria-valuenow", String(pct));
+		}
+	}
+	if (dom.progressPercent) {
+		dom.progressPercent.textContent = `${pct}%`;
+	}
+	if (dom.progressLive) {
+		dom.progressLive.textContent = [phase, label, detail]
+			.filter(Boolean)
+			.join(". ");
+	}
+}
+
+export function showStatus(text) {
+	if (dom.statusText) dom.statusText.textContent = text;
+}
+
+export function showProgress(text) {
+	if (dom.progressIndicator) dom.progressIndicator.textContent = text;
+}
+
+export function setRunningControls(isRunning) {
+	if (dom.stopTestButton) {
+		dom.stopTestButton.hidden = !isRunning;
+		dom.stopTestButton.disabled = !isRunning;
+	}
+	if (dom.runAgainButton) {
+		dom.runAgainButton.disabled = isRunning;
+	}
+	if (dom.editProvidersBtn) dom.editProvidersBtn.disabled = isRunning;
+	if (dom.editDomainsBtn) dom.editDomainsBtn.disabled = isRunning;
+	if (dom.exportCsvButton) {
+		dom.exportCsvButton.disabled = isRunning;
+	}
+	if (dom.shareResultsButton) {
+		dom.shareResultsButton.disabled = isRunning;
+	}
+}
 
 export function createInitialUI() {
 	const state = getState();
 	dom.mainGraphContainer.innerHTML = "";
 	dom.detailedGraphsContainer.innerHTML = "";
 	dom.errorSummary.style.display = "none";
-	dom.recommendationSection.style.display = "none";
+	if (dom.recommendationSection) {
+		dom.recommendationSection.style.display = "none";
+	}
 	dom.exportCsvButton.style.display = "none";
-	dom.comparisonContent.innerHTML = `<p style="text-align: center; color: var(--text-muted);">Run a test to see detailed comparison data</p>`;
+	if (dom.shareResultsButton) dom.shareResultsButton.style.display = "none";
+	dom.comparisonContent.innerHTML = `<p class="empty-state">Results will appear here after a full run.</p>`;
+	setHeroMode("progress");
+	setProgress({
+		phase: "Ready",
+		label: "Waiting to start…",
+		detail: "",
+		overallIndex: 0,
+		overallTotal: 1,
+	});
 
 	state.providers.forEach(({ name }) => {
 		const color = state.providerColors[name];
@@ -23,7 +122,7 @@ export function createInitialUI() {
                 <div class="bar-container">
                     <div class="bar" id="bar-${safeName}" style="background-color: ${color};"></div>
                 </div>
-                <div class="latency-value" id="latency-${safeName}">- ms</div>
+                <div class="latency-value" id="latency-${safeName}">—</div>
             </div>`;
 
 		dom.detailedGraphsContainer.innerHTML += `
@@ -33,7 +132,7 @@ export function createInitialUI() {
                         <span class="card-color-dot" style="background-color: ${color};"></span>
                         <h3 class="card-title">${name}</h3>
                     </div>
-                    <div class="card-stats" id="stats-${safeName}">Waiting...</div>
+                    <div class="card-stats" id="stats-${safeName}">Waiting…</div>
                 </div>
                 <div class="detailed-results" id="results-${safeName}">
                     <div class="detailed-row header">
@@ -53,7 +152,6 @@ export function displayDetailedBreakdown(providerName, breakdownData) {
 	const container = document.getElementById(`results-${safeProviderName}`);
 	if (!container) return;
 
-	// Start after the header row
 	for (const domain of getState().domains) {
 		const stats = breakdownData[domain];
 		if (!stats) continue;
@@ -66,14 +164,14 @@ export function displayDetailedBreakdown(providerName, breakdownData) {
 				? `<span class="detailed-latency cached">${stats.cachedAvg.toFixed(
 						0,
 				  )}</span>`
-				: `<span class="detailed-latency na">-</span>`;
+				: `<span class="detailed-latency na">—</span>`;
 
 		const uncachedAvgHtml =
 			stats.uncachedAvg !== null
 				? `<span class="detailed-latency uncached">${stats.uncachedAvg.toFixed(
 						0,
 				  )}</span>`
-				: `<span class="detailed-latency na">-</span>`;
+				: `<span class="detailed-latency na">—</span>`;
 
 		row.innerHTML = `
             <strong class="domain-name">${domain}</strong>
@@ -103,7 +201,7 @@ export function updateCardStats(name, allStats) {
 	if (statsEl && allStats.count > 0) {
 		statsEl.innerHTML = `Median: <strong>${allStats.median.toFixed(
 			0,
-		)}ms</strong> | Avg: <strong>${allStats.average.toFixed(0)}ms</strong>`;
+		)}ms</strong> · Avg: <strong>${allStats.average.toFixed(0)}ms</strong>`;
 	}
 }
 
@@ -113,28 +211,30 @@ export function showCard(name) {
 	if (card) card.classList.add("visible");
 }
 
-// --- FIX: Complete overhaul of the comparison table function ---
-export function createComparisonTable(allProviderStats) {
+export function createComparisonTable(allProviderStats, medianRanks) {
 	const state = getState();
 	if (Object.keys(allProviderStats).length === 0) return;
 
-	// Convert stats object to an array for easier sorting
 	const tableData = Object.entries(allProviderStats)
-		.filter(([_, stats]) => stats.count > 0)
-		.map(([name, stats]) => ({ name, ...stats }));
+		.filter(([, stats]) => stats.count > 0)
+		.map(([name, stats]) => ({
+			name,
+			medianRank: medianRanks[name] || 99,
+			...stats,
+		}));
 
 	let currentSortKey = "median";
 	let isSortAscending = true;
 
 	const headers = [
-		{ key: "rank", label: "Rank" },
-		{ key: "name", label: "Provider" },
-		{ key: "median", label: "Median" },
-		{ key: "average", label: "Avg Latency" },
-		{ key: "cachedAvg", label: "Cached Avg" },
-		{ key: "uncachedAvg", label: "Uncached Avg" },
-		{ key: "stdDev", label: "Std Deviation" },
-		{ key: "reliability", label: "Reliability" },
+		{ key: "medianRank", label: "Rank", sortable: true },
+		{ key: "name", label: "Provider", sortable: true },
+		{ key: "median", label: "Median", sortable: true },
+		{ key: "average", label: "Avg Latency", sortable: true },
+		{ key: "cachedAvg", label: "Cached Avg", sortable: true },
+		{ key: "uncachedAvg", label: "Uncached Avg", sortable: true },
+		{ key: "stdDev", label: "Std Deviation", sortable: true },
+		{ key: "reliability", label: "Reliability", sortable: true },
 	];
 
 	function handleHeaderClick(e) {
@@ -145,67 +245,74 @@ export function createComparisonTable(allProviderStats) {
 			isSortAscending = !isSortAscending;
 		} else {
 			currentSortKey = newSortKey;
-			isSortAscending = true;
+			isSortAscending = newSortKey === "name" ? true : true;
+			if (
+				["median", "average", "cachedAvg", "uncachedAvg", "stdDev", "medianRank"].includes(
+					newSortKey,
+				)
+			) {
+				isSortAscending = true;
+			}
 		}
 		renderTable();
 	}
 
 	function attachHeaderListeners() {
-		const headerElements = document.querySelectorAll(
-			".comparison-table th[data-sort-key]",
-		);
-		headerElements.forEach((th) => {
-			th.addEventListener("click", handleHeaderClick);
-		});
+		document
+			.querySelectorAll(".comparison-table th[data-sort-key]")
+			.forEach((th) => th.addEventListener("click", handleHeaderClick));
 	}
 
 	function renderTable() {
-		// Sort the data
 		tableData.sort((a, b) => {
 			const valA = a[currentSortKey];
 			const valB = b[currentSortKey];
-
+			if (typeof valA === "string") {
+				return isSortAscending
+					? valA.localeCompare(valB)
+					: valB.localeCompare(valA);
+			}
 			if (valA < valB) return isSortAscending ? -1 : 1;
 			if (valA > valB) return isSortAscending ? 1 : -1;
 			return 0;
 		});
 
-		// Build the table HTML
 		let tableHTML = `<table class="comparison-table"><thead><tr>`;
 
 		headers.forEach((header) => {
 			const isSorted = header.key === currentSortKey;
 			const sortIndicator = isSorted
-				? `<span class="sort-indicator">${
+				? `<span class="sort-indicator" aria-hidden="true">${
 						isSortAscending ? "▲" : "▼"
 				  }</span>`
 				: "";
 			const sortedClass = isSorted ? "sorted" : "";
-			// Only add data-sort-key to sortable columns
-			const sortableAttr =
-				header.key !== "rank" ? `data-sort-key="${header.key}"` : "";
+			const ariaSort = isSorted
+				? isSortAscending
+					? 'aria-sort="ascending"'
+					: 'aria-sort="descending"'
+				: 'aria-sort="none"';
+			const sortableAttr = header.sortable
+				? `data-sort-key="${header.key}" tabindex="0" role="columnheader" ${ariaSort}`
+				: "";
 			tableHTML += `<th class="${sortedClass}" ${sortableAttr}>${header.label}${sortIndicator}</th>`;
 		});
 
 		tableHTML += `</tr></thead><tbody>`;
 
-		tableData.forEach((stats, index) => {
-			const rank = index + 1;
+		tableData.forEach((stats) => {
+			const rank = stats.medianRank;
 			const rankClass = rank <= 3 ? `rank-${rank}` : "";
 			tableHTML += `
                 <tr style="border-left: 4px solid ${
 					state.providerColors[stats.name]
 				};">
                     <td><span class="rank-badge ${rankClass}">#${rank}</span></td>
-                    <td style="font-weight: 600;">${stats.name}</td>
-                    <td style="font-weight: 700;">${stats.median.toFixed(
-						1,
-					)} ms</td>
+                    <td class="provider-cell">${stats.name}</td>
+                    <td class="emphasis">${stats.median.toFixed(1)} ms</td>
                     <td>${stats.average.toFixed(1)} ms</td>
-                    <td style="color: var(--success-color);">${stats.cachedAvg.toFixed(
-						1,
-					)} ms</td>
-                    <td style="color: var(--warning-color);">${stats.uncachedAvg.toFixed(
+                    <td class="cached-cell">${stats.cachedAvg.toFixed(1)} ms</td>
+                    <td class="uncached-cell">${stats.uncachedAvg.toFixed(
 						1,
 					)} ms</td>
                     <td>&plusmn;${stats.stdDev.toFixed(1)} ms</td>
@@ -215,28 +322,40 @@ export function createComparisonTable(allProviderStats) {
 
 		tableHTML += "</tbody></table>";
 		dom.comparisonContent.innerHTML = tableHTML;
-
-		// Re-attach listeners since we overwrote the DOM
 		attachHeaderListeners();
 	}
 
-	// Initial render
 	renderTable();
 }
 
-export function displayRecommendation(recommendation) {
-	if (recommendation) {
-		dom.recommendationText.innerHTML = recommendation;
-		dom.recommendationSection.style.display = "block";
+export function displayRecommendation(recommendation, incomplete = false) {
+	if (!recommendation) {
+		setHeroMode("progress");
+		return;
+	}
+
+	dom.recommendationText.innerHTML = incomplete
+		? `<strong>Incomplete run.</strong> ${recommendation.html}`
+		: recommendation.html;
+
+	if (dom.recommendationMeta) {
+		dom.recommendationMeta.innerHTML = `
+			<span class="meta-pill">${recommendation.winnerName}</span>
+			<span class="meta-pill">${recommendation.median.toFixed(0)} ms median</span>
+			<span class="meta-pill">${recommendation.reliability.toFixed(0)}% reliable</span>
+		`;
+	}
+
+	setHeroMode("recommendation");
+	if (dom.recommendationSection) {
+		dom.recommendationSection.style.display = "none";
 	}
 }
 
-export function showStatus(text) {
-	dom.statusText.textContent = text;
-}
-
-export function showProgress(text) {
-	dom.progressIndicator.textContent = text;
+export function showIncompleteState(message) {
+	setHeroMode("recommendation");
+	dom.recommendationText.innerHTML = message;
+	if (dom.recommendationMeta) dom.recommendationMeta.innerHTML = "";
 }
 
 export function exportToCSV(allProviderStats) {
@@ -262,4 +381,42 @@ export function exportToCSV(allProviderStats) {
 	document.body.appendChild(link);
 	link.click();
 	document.body.removeChild(link);
+}
+
+export async function shareResults() {
+	const state = getState();
+	const text = buildShareSummary(
+		state.allProviderStats,
+		state.medianRanks,
+		state.lastQueryCount || "?",
+	);
+
+	try {
+		if (navigator.share) {
+			await navigator.share({
+				title: "DNS Bench Pro results",
+				text,
+			});
+			return;
+		}
+	} catch (err) {
+		if (err && err.name === "AbortError") return;
+	}
+
+	try {
+		await navigator.clipboard.writeText(text);
+		showStatus("Results copied to clipboard.");
+	} catch {
+		showStatus("Unable to share automatically. Use Export to CSV instead.");
+	}
+}
+
+export function refreshDurationEstimates(estimateFn) {
+	document.querySelectorAll(".duration-btn").forEach((btn) => {
+		const queries = parseInt(btn.dataset.queries, 10);
+		const slot = btn.querySelector("[data-estimate]");
+		if (slot && estimateFn) {
+			slot.textContent = estimateFn(queries);
+		}
+	});
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the full A→E UI/UX plan for DNS Bench Pro: clearer progress and stop controls, a results hero with honest ranking, pre-test configuration, a brand refresh, and share/a11y/help polish.

## What changed

### Pass A — Progress + stop + profiles
- Structured progress (warm-up vs measuring) with determinate bar and %
- **Stop test** with abortable in-flight DoH requests
- Profile cards with live duration estimates, Cancel, and Esc

### Pass B — Results hierarchy
- Results hero: progress during the run, recommendation after
- Comparison **median ranks** stay fixed when sorting columns

### Pass C — Pre-test config
- **Configure** from the start screen (providers/sites counts)
- Presets (Default / Privacy / Minimal) + Reset
- HTTPS URL and domain validation; preserve `type` / `allowCors`

### Pass D — Brand + motion
- Space Grotesk / IBM Plex Sans / IBM Plex Mono
- Night-lab dark palette with teal accent (no purple edit / cyan glow pills)
- Intentional motion + `prefers-reduced-motion` support

### Pass E — Share, a11y, meta, help
- Favicon + meta/OG tags
- Share results (Web Share or clipboard) alongside CSV export
- Help modal (DoH, warm-up, cached vs uncached, privacy)
- Shared modal focus trap / Esc / focus restore; live progress region
- README usage corrected (manual start, not auto-start)

## Test plan
- [ ] Start → profile estimates update → Cancel / Esc does not start
- [ ] Run Quick test; progress bar advances through warm-up and measure
- [ ] Stop mid-run; partial results / incomplete messaging appear
- [ ] Complete run; recommendation hero shows; table sort keeps median ranks
- [ ] Configure presets / reset / invalid URL blocked before start
- [ ] Share copies summary; Help modal keyboard Esc works
- [ ] Mobile layout: start hero, graph footer, modals usable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bce9c59-7438-4e28-bab3-d666144af282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bce9c59-7438-4e28-bab3-d666144af282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

