### PR TITLE
perf: add parallel multi-ping benchmark rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 * **Client-side only** — queries run from your browser; this site does not log your IP or results.
 * **Test profiles** — Quick, Balanced, Thorough, or Comprehensive query depths with time estimates.
+* **Multi-ping execution** — independent sites are queried in parallel for faster runs without changing the sample count.
 * **Live progress** — warm-up vs measuring phases, determinate progress, and Stop.
 * **Configurable** — edit providers and sites, apply presets, or reset to defaults before you run.
 * **Clear results** — recommendation hero, live latency bars, cached vs uncached breakdown, sortable comparison with stable median ranks, CSV export, and share/copy summary.
@@ -20,7 +21,7 @@
 
 ## How it works
 
-The app measures DoH latency against a list of public resolvers and popular domains. A warm-up pass primes connections so cold TCP/TLS handshakes do not dominate the first timed queries. The first query per domain uses a random subdomain (uncached path); later queries measure warmer/cached responses.
+The app measures DoH latency against a list of public resolvers and popular domains. A warm-up pass primes each provider’s connections, with the sites probed in parallel so cold TCP/TLS handshakes do not dominate the first timed queries. Measurement rounds also query all sites for one provider in parallel; providers and rounds remain sequential so the first query per domain still uses a random subdomain (uncached path), while later queries measure warmer/cached responses.
 
 ## Local development
 

--- a/index.html
+++ b/index.html
@@ -55,25 +55,25 @@
 						>
 							<span class="duration-label">Quick</span>
 							<span class="duration-meta">3 queries/url</span>
-							<span class="duration-estimate" data-estimate>~30s</span>
+							<span class="duration-estimate" data-estimate>~5s</span>
 							<span class="duration-hint">Best for a fast check</span>
 						</button>
 						<button type="button" class="duration-btn" data-queries="6">
 							<span class="duration-label">Balanced</span>
 							<span class="duration-meta">6 queries/url</span>
-							<span class="duration-estimate" data-estimate>~1 min</span>
+							<span class="duration-estimate" data-estimate>~8s</span>
 							<span class="duration-hint">Recommended default</span>
 						</button>
 						<button type="button" class="duration-btn" data-queries="18">
 							<span class="duration-label">Thorough</span>
 							<span class="duration-meta">18 queries/url</span>
-							<span class="duration-estimate" data-estimate>~3 min</span>
+							<span class="duration-estimate" data-estimate>~23s</span>
 							<span class="duration-hint">More stable medians</span>
 						</button>
 						<button type="button" class="duration-btn" data-queries="36">
 							<span class="duration-label">Comprehensive</span>
 							<span class="duration-meta">36 queries/url</span>
-							<span class="duration-estimate" data-estimate>~6 min</span>
+							<span class="duration-estimate" data-estimate>~44s</span>
 							<span class="duration-hint">Highest confidence</span>
 						</button>
 					</div>

--- a/js/api.js
+++ b/js/api.js
@@ -10,6 +10,12 @@ export async function warmUpConnection(provider, domain) {
 	await measureDohLatency(provider, domain, getAbortSignal());
 }
 
+export async function warmUpConnections(provider, domains) {
+	await Promise.all(
+		domains.map((domain) => warmUpConnection(provider, domain)),
+	);
+}
+
 export async function measureLatency(provider, domain, isUncached) {
 	const domainToQuery = isUncached
 		? `${Math.random().toString(36).substring(7)}.${domain}`
@@ -26,4 +32,10 @@ export async function measureLatency(provider, domain, isUncached) {
 		dnssecSupported: Math.random() > 0.1,
 		error: latency === null ? "failed" : null,
 	};
+}
+
+export function measureLatencyBatch(provider, domains, isUncached) {
+	return Promise.all(
+		domains.map((domain) => measureLatency(provider, domain, isUncached)),
+	);
 }

--- a/js/config.js
+++ b/js/config.js
@@ -245,12 +245,12 @@ export function applyPreset(presetId) {
 
 export function estimateTestDuration(queryCount) {
 	const providers = state.providers.length;
-	const domains = state.domains.length;
-	const warmUps = providers * domains;
-	const measures = providers * domains * queryCount;
-	// ~120ms per warm-up attempt + ~150ms per measure (incl. delay) + gaps
-	const seconds = Math.round((warmUps * 0.12 + measures * 0.18 + providers * 0.5));
-	if (seconds < 45) return `~${Math.max(15, seconds)}s`;
+	// Domains are multi-pinged per provider and per query round.
+	// Keep a conservative estimate for network and browser scheduling overhead.
+	const warmUpSeconds = providers * 0.18;
+	const measureSeconds = providers * queryCount * 0.2;
+	const seconds = Math.round(warmUpSeconds + measureSeconds);
+	if (seconds < 60) return `~${Math.max(5, seconds)}s`;
 	if (seconds < 120) return `~${Math.round(seconds / 15) * 15}s`;
 	const minutes = seconds / 60;
 	if (minutes < 3) return `~${minutes.toFixed(1)} min`;

--- a/js/main.js
+++ b/js/main.js
@@ -22,37 +22,47 @@ function progressTotals(queryCount) {
 
 async function runTestForProvider(provider, queriesPerUrl, progressOffset, totals) {
 	const state = getState();
+	const domains = [...state.domains];
 	const allResults = [];
 	let runningTotalLatency = 0;
 	let successfulQueryCount = 0;
 
-	const totalQueries = queriesPerUrl * state.domains.length;
+	const totalQueries = queriesPerUrl * domains.length;
 	let currentQueryIndex = 0;
 	const providerIndex =
 		state.providers.findIndex((p) => p.name === provider.name) + 1;
 
 	ui.showStatus(`Testing ${provider.name}…`);
 
-	for (const domain of state.domains) {
+	for (let round = 0; round < queriesPerUrl; round++) {
 		if (!state.isTestRunning) break;
 
-		for (let i = 0; i < queriesPerUrl; i++) {
-			if (!state.isTestRunning) break;
+		const isUncached = round === 0;
+		const roundStartIndex = round * domains.length;
+		ui.setProgress({
+			phase: "Measuring",
+			label: `${provider.name} (${providerIndex}/${state.providers.length})`,
+			detail: `Round ${round + 1}/${queriesPerUrl} · ${domains.length} sites in parallel`,
+			overallIndex: progressOffset + roundStartIndex,
+			overallTotal: totals.overall,
+		});
 
+		const results = await api.measureLatencyBatch(
+			provider,
+			domains,
+			isUncached,
+		);
+
+		results.forEach((result, index) => {
+			const domain = domains[index];
 			currentQueryIndex++;
-			const overallIndex = progressOffset + currentQueryIndex;
-
-			ui.setProgress({
-				phase: "Measuring",
-				label: `${provider.name} (${providerIndex}/${state.providers.length})`,
-				detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain}`,
-				overallIndex,
-				overallTotal: totals.overall,
-			});
-
-			const isUncached = i === 0;
-			const result = await api.measureLatency(provider, domain, isUncached);
 			allResults.push({ ...result, isUncached, domain });
+
+			const overallIndex = progressOffset + currentQueryIndex;
+			const resultDetail =
+				result.latency !== null
+					? `${result.latency.toFixed(0)} ms`
+					: "failed";
 
 			if (result.latency !== null) {
 				successfulQueryCount++;
@@ -60,28 +70,16 @@ async function runTestForProvider(provider, queriesPerUrl, progressOffset, total
 				const runningAverage =
 					runningTotalLatency / successfulQueryCount;
 				ui.updateMainGraph(provider.name, runningAverage);
-
-				ui.setProgress({
-					phase: "Measuring",
-					label: `${provider.name} (${providerIndex}/${state.providers.length})`,
-					detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain} · ${result.latency.toFixed(
-						0,
-					)} ms`,
-					overallIndex,
-					overallTotal: totals.overall,
-				});
-			} else {
-				ui.setProgress({
-					phase: "Measuring",
-					label: `${provider.name} (${providerIndex}/${state.providers.length})`,
-					detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain} · failed`,
-					overallIndex,
-					overallTotal: totals.overall,
-				});
 			}
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		}
+			ui.setProgress({
+				phase: "Measuring",
+				label: `${provider.name} (${providerIndex}/${state.providers.length})`,
+				detail: `Query ${currentQueryIndex}/${totalQueries} · ${domain} · ${resultDetail}`,
+				overallIndex,
+				overallTotal: totals.overall,
+			});
+		});
 	}
 
 	if (allResults.length === 0) return;
@@ -128,6 +126,7 @@ async function runTestForProvider(provider, queriesPerUrl, progressOffset, total
 
 async function warmUpAllProviders(totals) {
 	const state = getState();
+	const domains = [...state.domains];
 	state.runPhase = "warmup";
 	ui.setProgress({
 		phase: "Warm-up",
@@ -140,18 +139,26 @@ async function warmUpAllProviders(totals) {
 	let warmUpCount = 0;
 
 	for (const provider of state.providers) {
-		for (const domain of state.domains) {
-			if (!getState().isTestRunning) return;
-			warmUpCount++;
-			ui.setProgress({
-				phase: "Warm-up",
-				label: "Priming DNS connections…",
-				detail: `${provider.name} · ${domain} (${warmUpCount}/${totals.warmUps})`,
-				overallIndex: warmUpCount,
-				overallTotal: totals.overall,
-			});
-			await api.warmUpConnection(provider, domain);
-		}
+		if (!getState().isTestRunning) return;
+
+		ui.setProgress({
+			phase: "Warm-up",
+			label: "Priming DNS connections…",
+			detail: `${provider.name} · ${domains.length} sites in parallel`,
+			overallIndex: warmUpCount,
+			overallTotal: totals.overall,
+		});
+
+		await api.warmUpConnections(provider, domains);
+		warmUpCount += domains.length;
+
+		ui.setProgress({
+			phase: "Warm-up",
+			label: "Priming DNS connections…",
+			detail: `${provider.name} · ready (${warmUpCount}/${totals.warmUps})`,
+			overallIndex: warmUpCount,
+			overallTotal: totals.overall,
+		});
 	}
 }
 
@@ -203,10 +210,6 @@ async function startTest(queryCount) {
 					totals,
 				);
 				measureOffset += state.domains.length * queryCount;
-
-				if (i < state.providers.length - 1 && state.isTestRunning) {
-					await new Promise((resolve) => setTimeout(resolve, 500));
-				}
 			}
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run each provider's warm-up domains concurrently
- run each provider's query rounds as parallel multi-pings while preserving uncached-first semantics
- remove artificial inter-query and inter-provider delays
- update duration estimates and documentation for the faster execution model

## Validation
- JavaScript syntax checks passed for all `js/*.js` files
- Node smoke test confirmed one successful result per domain with concurrent execution
- CRLF-aware diff whitespace check passed
- Preview deployment check passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cfa8837-7952-4b34-9b23-b2565d32ac93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cfa8837-7952-4b34-9b23-b2565d32ac93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

